### PR TITLE
Pass meta data

### DIFF
--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -320,6 +320,10 @@ class Stripe extends BasePaymentGateway
             'transactionId' => $order->order_id,
             'returnUrl' => $returnUrl,
             'confirm' => TRUE,
+            'metadata' => [
+				'order_id' => $order->order_id,
+				'customer_email' => $order->email
+			]
         ];
 
         $this->fireSystemEvent('payregister.stripe.extendFields', [&$fields, $order, $data]);

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -321,9 +321,9 @@ class Stripe extends BasePaymentGateway
             'returnUrl' => $returnUrl,
             'confirm' => TRUE,
             'metadata' => [
-				'order_id' => $order->order_id,
-				'customer_email' => $order->email
-			]
+                'order_id' => $order->order_id,
+                'customer_email' => $order->email,
+            ],
         ];
 
         $this->fireSystemEvent('payregister.stripe.extendFields', [&$fields, $order, $data]);


### PR DESCRIPTION
I don't think 'transactionId' has any effect any more with Stripe (i didn't remove it in case its an Omnipay requirement). Instead pass order id and customer email via meta data so that they can be found in the Stripe dashboard.