### PR TITLE
Update to ensure backwards compatibility

### DIFF
--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -47,9 +47,9 @@ class Stripe extends BasePaymentGateway
         return $this->isTestMode() ? $this->model->test_secret_key : $this->model->live_secret_key;
     }
 
-    public function shouldCapturePayment()
+    public function shouldAuthorizePayment()
     {
-        return !($this->model->transaction_type && $this->model->transaction_type == 'auth_only');
+        return $this->model->transaction_type == 'auth_only';
     }
 
     public function isApplicable($total, $host)
@@ -342,7 +342,7 @@ class Stripe extends BasePaymentGateway
 
     protected function createPurchaseRequest(array $fields, array $data)
     {
-        $method = $this->shouldCapturePayment() ? 'purchase' : 'authorize';
+        $method = $this->shouldAuthorizePayment() ? 'authorize' : 'purchase';
         $request = $this->createGateway()->$method($fields);
         $request->setIdempotencyKeyHeader(array_get($data, 'stripe_idempotency_key'));
 

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -49,7 +49,7 @@ class Stripe extends BasePaymentGateway
 
     public function shouldCapturePayment()
     {
-        return $this->model->transaction_type && $this->model->transaction_type != 'auth_only';
+        return !($this->model->transaction_type && $this->model->transaction_type == 'auth_only');
     }
 
     public function isApplicable($total, $host)


### PR DESCRIPTION
Sorry to make a change after merging already - I just took a second look at this and realised that it would break backwards compatibility - this fix should ensure if there is no transaction_type specified or if its not auth_only then we create it as capture.