### PR TITLE
Persist idempotency key to truly avoid duplicate charges

### DIFF
--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -111,6 +111,9 @@ class Stripe extends BasePaymentGateway
                 return Redirect::to($response->getRedirectUrl());
             }
 
+            if ($response->isSuccessful())
+                Session::forget('ti_payregister_stripe_idempotency_key');
+
             $this->handlePaymentResponse($response, $order, $host, $fields);
         }
         catch (Exception $ex) {
@@ -150,6 +153,8 @@ class Stripe extends BasePaymentGateway
 
             if (!$response->isSuccessful())
                 throw new ApplicationException($response->getMessage());
+
+            Session::forget('ti_payregister_stripe_idempotency_key');
 
             $order->logPaymentAttempt('Payment successful', 1, $fields, $response->getData());
             $order->updateOrderStatus($paymentMethod->order_status, ['notify' => FALSE]);
@@ -220,6 +225,9 @@ class Stripe extends BasePaymentGateway
 
                 return Redirect::to($response->getRedirectUrl());
             }
+
+            if ($response->isSuccessful())
+                Session::forget('ti_payregister_stripe_idempotency_key');
 
             $this->handlePaymentResponse($response, $order, $host, $fields);
         }

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -8,6 +8,7 @@ use ApplicationException;
 use Exception;
 use Igniter\Flame\Traits\EventEmitter;
 use Igniter\PayRegister\Traits\PaymentHelpers;
+use Illuminate\Support\Str;
 use Omnipay\Omnipay;
 use Redirect;
 use Session;
@@ -28,7 +29,7 @@ class Stripe extends BasePaymentGateway
     {
         return [
             'stripe_payment_method' => '',
-            'stripe_idempotency_key' => uniqid(),
+            'stripe_idempotency_key' => $this->getIdempotencyKey(),
         ];
     }
 
@@ -45,6 +46,17 @@ class Stripe extends BasePaymentGateway
     public function getSecretKey()
     {
         return $this->isTestMode() ? $this->model->test_secret_key : $this->model->live_secret_key;
+    }
+
+    public function getIdempotencyKey()
+    {
+        $idempotencyKey = Session::get('idempotency_key');
+        if (!strlen($idempotencyKey)) {
+            $idempotencyKey = Str::uuid();
+            Session::put('idempotency_key', $idempotencyKey);
+        }
+
+        return $idempotencyKey;
     }
 
     public function shouldAuthorizePayment()

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -50,10 +50,10 @@ class Stripe extends BasePaymentGateway
 
     public function getIdempotencyKey()
     {
-        $idempotencyKey = Session::get('idempotency_key');
+        $idempotencyKey = Session::get('ti_payregister_stripe_idempotency_key');
         if (!strlen($idempotencyKey)) {
             $idempotencyKey = Str::uuid();
-            Session::put('idempotency_key', $idempotencyKey);
+            Session::put('ti_payregister_stripe_idempotency_key', $idempotencyKey);
         }
 
         return $idempotencyKey;


### PR DESCRIPTION
According to [stripe docs](https://stripe.com/docs/api/idempotent_requests), the idempotency key must be same across requests to avoid duplicate charges. This PR stores the key in session so subsequent requests can use the same key but we also need to figure a way to clear this session after successful payment.

@ryanmitchell let me know what you think.