### PR TITLE
Update process.square.js to use the WebPayments SDK instead of SqPaymentForm

### DIFF
--- a/assets/process.square.js
+++ b/assets/process.square.js
@@ -5,7 +5,7 @@
         this.$el = $(element)
         this.options = options || {}
         this.$checkoutForm = this.$el.closest('#checkout-form')
-        this.sq_el_id = 'sq-card'
+        this.sqElementID = 'sq-card'
         this.card = null
         this.payments = null
 
@@ -13,18 +13,18 @@
     }
 
     ProcessSquare.prototype.init = function () {
-        if (!$('#'+this.sq_el_id).length)
+        if (!$('#'+this.sqElementID).length)
             return
 
         if (this.options.applicationId === undefined)
             throw new Error('Missing square application id')
 
         this.payments = window.Square.payments(this.options.applicationId, this.options.locationId);
-        try {
-            this.initializeCard(this.payments);
-        } catch (e) {
+        
+        this.initializeCard(this.payments).catch(e => {
             throw new Error('Initializing Card failed', e)
-        }
+        });
+
         this.$checkoutForm.on('submitCheckoutForm', $.proxy(this.submitFormHandler, this))
     }
 
@@ -46,7 +46,7 @@
                 }
             }
         });
-        await this.card.attach('#' + this.sq_el_id); 
+        await this.card.attach('#' + this.sqElementID); 
     }
 
     ProcessSquare.prototype.submitFormHandler = async function (event) {

--- a/assets/process.square.js
+++ b/assets/process.square.js
@@ -75,7 +75,7 @@
         var verificationToken = await this.verifyBuyerHelper(tokenResult, verificationDetails);
         
         $form.find('input[name="square_card_nonce"]').val(tokenResult.token);
-        $form.find('input[name="square_card_token"]').val(verificationToken.token);
+        $form.find('input[name="square_card_token"]').val(verificationToken);
 
         // Switch back to default to submit form
         $form.unbind('submitCheckoutForm').submit()

--- a/assets/process.square.js
+++ b/assets/process.square.js
@@ -32,19 +32,7 @@
 
         // Customize the CSS for WebPayments SDK elements
         this.card = await payments.card({
-            style: {
-                input: {
-                    backgroundColor: '#FFF',
-                    color: '#000000',
-                    fontSize: '16px'
-                },
-                'input::placeholder': {
-                    color: '#A5A5A5',
-                },
-                '.message-icon': {
-                    color: '#A5A5A5',
-                }
-            }
+            style: this.options.cardFormStyle
         });
         await this.card.attach('#' + this.sqElementID); 
     }
@@ -108,7 +96,20 @@
         locationId: undefined,
         orderTotal: undefined,
         currencyCode: undefined,
-        errorSelector: '#square-card-errors'
+        errorSelector: '#square-card-errors',
+        cardFormStyle: {
+            input: {
+                backgroundColor: '#FFF',
+                color: '#000000',
+                fontSize: '16px'
+            },
+            'input::placeholder': {
+                color: '#A5A5A5',
+            },
+            '.message-icon': {
+                color: '#A5A5A5',
+            }
+        }
     }
 
     // PLUGIN DEFINITION

--- a/assets/process.square.js
+++ b/assets/process.square.js
@@ -20,7 +20,7 @@
             throw new Error('Missing square application id')
 
         this.payments = window.Square.payments(this.options.applicationId, this.options.locationId);
-        
+
         this.initializeCard(this.payments).catch(e => {
             throw new Error('Initializing Card failed', e)
         });
@@ -34,7 +34,7 @@
         this.card = await payments.card({
             style: this.options.cardFormStyle
         });
-        await this.card.attach('#' + this.sqElementID); 
+        await this.card.attach('#' + this.sqElementID);
     }
 
     ProcessSquare.prototype.submitFormHandler = async function (event) {
@@ -71,15 +71,15 @@
             $form.find(this.options.errorSelector).html($el);
             return;
         }
-        
+
         var verificationToken = await this.verifyBuyerHelper(tokenResult, verificationDetails);
-        
+
         $form.find('input[name="square_card_nonce"]').val(tokenResult.token);
         $form.find('input[name="square_card_token"]').val(verificationToken);
 
         // Switch back to default to submit form
         $form.unbind('submitCheckoutForm').submit()
-        
+
     }
 
     ProcessSquare.prototype.verifyBuyerHelper = async function(paymentToken, verificationDetails) {

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -49,7 +49,7 @@ class Square extends BasePaymentGateway
 
     /**
      * @param  self $host
-     * @param  \Main\Classes\MainController $controller
+     * @param  \Main\Classes\MainController  $controller
      */
     public function beforeRenderPaymentForm($host, $controller)
     {
@@ -62,8 +62,8 @@ class Square extends BasePaymentGateway
      * Processes payment using passed data.
      *
      * @param  array $data
-     * @param  \Admin\Models\Payments_model $host
-     * @param  \Admin\Models\Orders_model $order
+     * @param  \Admin\Models\Payments_model  $host
+     * @param  \Admin\Models\Orders_model  $order
      *
      * @throws \Igniter\Flame\Exception\ApplicationException
      */
@@ -214,9 +214,9 @@ class Square extends BasePaymentGateway
     }
 
     /**
-     * @param  \Admin\Models\Payment_profiles_model $profile
-     * @param  array $profileData
-     * @param  array $cardData
+     * @param  \Admin\Models\Payment_profiles_model  $profile
+     * @param  array  $profileData
+     * @param  array  $cardData
      * @return \Admin\Models\Payment_profiles_model
      */
     protected function updatePaymentProfileData($profile, $profileData = [], $cardData = [])

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -58,6 +58,11 @@ class Square extends BasePaymentGateway
         $controller->addJs('$/igniter/payregister/assets/process.square.js', 'process-square-js');
     }
 
+    public function completesPaymentOnClient()
+    {
+        return TRUE;
+    }
+
     /**
      * Processes payment using passed data.
      *

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -48,8 +48,8 @@ class Square extends BasePaymentGateway
     }
 
     /**
-     * @param  self  $host
-     * @param  \Main\Classes\MainController  $controller
+     * @param self $host
+     * @param \Main\Classes\MainController $controller
      */
     public function beforeRenderPaymentForm($host, $controller)
     {
@@ -61,9 +61,9 @@ class Square extends BasePaymentGateway
     /**
      * Processes payment using passed data.
      *
-     * @param  array  $data
-     * @param  \Admin\Models\Payments_model  $host
-     * @param  \Admin\Models\Orders_model  $order
+     * @param array $data
+     * @param \Admin\Models\Payments_model $host
+     * @param \Admin\Models\Orders_model $order
      *
      * @throws \Igniter\Flame\Exception\ApplicationException
      */
@@ -214,9 +214,9 @@ class Square extends BasePaymentGateway
     }
 
     /**
-     * @param  \Admin\Models\Payment_profiles_model  $profile
-     * @param  array  $profileData
-     * @param  array  $cardData
+     * @param \Admin\Models\Payment_profiles_model $profile
+     * @param array $profileData
+     * @param array $cardData
      * @return \Admin\Models\Payment_profiles_model
      */
     protected function updatePaymentProfileData($profile, $profileData = [], $cardData = [])

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -48,8 +48,8 @@ class Square extends BasePaymentGateway
     }
 
     /**
-     * @param self $host
-     * @param \Main\Classes\MainController $controller
+     * @param  self $host
+     * @param  \Main\Classes\MainController $controller
      */
     public function beforeRenderPaymentForm($host, $controller)
     {
@@ -61,9 +61,9 @@ class Square extends BasePaymentGateway
     /**
      * Processes payment using passed data.
      *
-     * @param array $data
-     * @param \Admin\Models\Payments_model $host
-     * @param \Admin\Models\Orders_model $order
+     * @param  array $data
+     * @param  \Admin\Models\Payments_model $host
+     * @param  \Admin\Models\Orders_model $order
      *
      * @throws \Igniter\Flame\Exception\ApplicationException
      */
@@ -214,9 +214,9 @@ class Square extends BasePaymentGateway
     }
 
     /**
-     * @param \Admin\Models\Payment_profiles_model $profile
-     * @param array $profileData
-     * @param array $cardData
+     * @param  \Admin\Models\Payment_profiles_model $profile
+     * @param  array $profileData
+     * @param  array $cardData
      * @return \Admin\Models\Payment_profiles_model
      */
     protected function updatePaymentProfileData($profile, $profileData = [], $cardData = [])

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -53,8 +53,8 @@ class Square extends BasePaymentGateway
      */
     public function beforeRenderPaymentForm($host, $controller)
     {
-        $endpoint = $this->isTestMode() ? 'squareupsandbox' : 'squareup';
-        $controller->addJs('https://js.'.$endpoint.'.com/v2/paymentform', 'square-js');
+        $endpoint = $this->isTestMode() ? 'sandbox.' : '';
+        $controller->addJs('https://'.$endpoint.'web.squarecdn.com/v1/square.js', 'square-js');
         $controller->addJs('$/igniter/payregister/assets/process.square.js', 'process-square-js');
     }
 

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -48,7 +48,7 @@ class Square extends BasePaymentGateway
     }
 
     /**
-     * @param  self $host
+     * @param  self  $host
      * @param  \Main\Classes\MainController  $controller
      */
     public function beforeRenderPaymentForm($host, $controller)
@@ -61,7 +61,7 @@ class Square extends BasePaymentGateway
     /**
      * Processes payment using passed data.
      *
-     * @param  array $data
+     * @param  array  $data
      * @param  \Admin\Models\Payments_model  $host
      * @param  \Admin\Models\Orders_model  $order
      *


### PR DESCRIPTION
Deprecation warning no longer shows up in the web console. 

I've only tested in sandbox, but can confirm that behaviors are the same between the old SqPaymentForms implementation and this one. I've 'tested' the SCA process in sandbox with the values described in https://developer.squareup.com/docs/testing/test-values, but as I don't have an EU bank account I have no clue what this looks like in production.