### PR TITLE
Fix: stripe payment logged twice

### DIFF
--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -166,6 +166,18 @@ class Stripe extends BasePaymentGateway
                 'amount', 'currency', 'capture_method', 'setup_future_usage',
             ]), $stripeOptions);
 
+            // Avoid logging payment and updating the order status more than once
+            // For cases where the webhook is triggered before the user is redirected
+            if ($order->isPaymentProcessed())
+                return true;
+
+            if ($paymentIntent->status === 'requires_capture') {
+                $order->logPaymentAttempt('Payment authorized', 1, $data, $paymentIntent->toArray());
+            }
+            else {
+                $order->logPaymentAttempt('Payment successful', 1, $data, $paymentIntent->toArray(), true);
+            }
+
             $order->updateOrderStatus($host->order_status, ['notify' => false]);
             $order->markAsPaymentProcessed();
 
@@ -574,10 +586,10 @@ class Stripe extends BasePaymentGateway
         if ($order = Orders_model::find($payload['data']['object']['metadata']['order_id'])) {
             if (!$order->isPaymentProcessed()) {
                 if ($payload['data']['object']['status'] === 'requires_capture') {
-                    $order->logPaymentAttempt('Payment authorized', 1, [], $payload['data']['object']);
+                    $order->logPaymentAttempt('Payment authorized via webhook', 1, [], $payload['data']['object']);
                 }
                 else {
-                    $order->logPaymentAttempt('Payment successful', 1, [], $payload['data']['object'], true);
+                    $order->logPaymentAttempt('Payment successful via webhook', 1, [], $payload['data']['object'], true);
                 }
 
                 $order->updateOrderStatus($this->model->order_status, ['notify' => false]);

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -166,13 +166,6 @@ class Stripe extends BasePaymentGateway
                 'amount', 'currency', 'capture_method', 'setup_future_usage',
             ]), $stripeOptions);
 
-            if ($paymentIntent->status === 'requires_capture') {
-                $order->logPaymentAttempt('Payment authorized', 1, $data, $paymentIntent->toArray());
-            }
-            else {
-                $order->logPaymentAttempt('Payment successful', 1, $data, $paymentIntent->toArray(), true);
-            }
-
             $order->updateOrderStatus($host->order_status, ['notify' => false]);
             $order->markAsPaymentProcessed();
 


### PR DESCRIPTION
### The problem
1. Enable stripe payment, and make a successful payment of an order 
2. Navigate to "Payment Attempts" in the detail of the order, and will see the payment get logged twice.

### The cause: where two logging happened
1. At the _processPaymentForm_ function, where my current code change modifying, the payment will be logged when the payment is successful.
2. At the _webhookHandlePaymentIntentSucceeded_ function. Stripe will send a request to our call back when the payment is successful.

![image](https://user-images.githubusercontent.com/12481493/187037800-59dd6dae-08ec-4dc6-ac41-f861f8c3d54f.png)


### The solution
My current solution may be not elegant, it is just simply deleting the logging logic in one of the functions. Please let me know if you have any other suggestions regarding the fix.