### PR TITLE
Make stripe webhook url generated

### DIFF
--- a/language/en/default.php
+++ b/language/en/default.php
@@ -116,6 +116,8 @@ return [
         'label_test_publishable_key' => 'Test Publishable Key',
         'label_live_secret_key' => 'Live Secret Key',
         'label_live_publishable_key' => 'Live Publishable Key',
+        'label_test_webhook_secret' => 'Test Webhook Secret',
+        'label_live_webhook_secret' => 'Live Webhook Secret',
         'label_locale_code' => 'Locale Code',
         'label_priority' => 'Priority',
         'label_status' => 'Status',

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -23,7 +23,7 @@ class Stripe extends BasePaymentGateway
     public function registerEntryPoints()
     {
         return [
-            $this->getWebhook() => 'processWebhookUrl',
+            'stripe_webhook' => 'processWebhookUrl',
         ];
     }
 
@@ -50,9 +50,9 @@ class Stripe extends BasePaymentGateway
         return $this->isTestMode() ? $this->model->test_secret_key : $this->model->live_secret_key;
     }
 
-    public function getWebhook()
+    public function getWebhookSecret()
     {
-        return $this->model->webhook;
+        return $this->isTestMode() ? $this->model->test_webhook_secret : $this->model->live_webhook_secret;
     }
 
     public function shouldAuthorizePayment()
@@ -566,7 +566,8 @@ class Stripe extends BasePaymentGateway
         if (strtolower(request()->method()) !== 'post')
             return response('Request method must be POST', 400);
 
-        $payload = json_decode(request()->getContent(), true);
+        $payload = $this->getWebhookPayload();
+
         if (!isset($payload['type']) || !strlen($eventType = $payload['type']))
             return response('Missing webhook event name', 400);
 
@@ -596,5 +597,19 @@ class Stripe extends BasePaymentGateway
                 $order->markAsPaymentProcessed();
             }
         }
+    }
+
+    protected function getWebhookPayload(): array
+    {
+        if (!$webhookSecret = $this->getWebhookSecret())
+            return json_decode(request()->getContent(), true);
+
+        $event = \Stripe\Webhook::constructEvent(
+            request()->getContent(),
+            request()->header('HTTP_STRIPE_SIGNATURE'),
+            $webhookSecret
+        );
+
+        return $event->toArray();
     }
 }

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -23,7 +23,7 @@ class Stripe extends BasePaymentGateway
     public function registerEntryPoints()
     {
         return [
-            'stripe_webhook' => 'processWebhookUrl',
+            $this->getWebhook() => 'processWebhookUrl',
         ];
     }
 
@@ -48,6 +48,11 @@ class Stripe extends BasePaymentGateway
     public function getSecretKey()
     {
         return $this->isTestMode() ? $this->model->test_secret_key : $this->model->live_secret_key;
+    }
+
+    public function getWebhook()
+    {
+        return $this->model->webhook;
     }
 
     public function shouldAuthorizePayment()

--- a/payments/stripe/fields.php
+++ b/payments/stripe/fields.php
@@ -26,6 +26,16 @@ return [
                 'auth_only' => 'lang:igniter.payregister::default.stripe.text_auth_only',
             ],
         ],
+        'live_publishable_key' => [
+            'label' => 'lang:igniter.payregister::default.stripe.label_live_publishable_key',
+            'type' => 'text',
+            'span' => 'right',
+            'trigger' => [
+                'action' => 'show',
+                'field' => 'transaction_mode',
+                'condition' => 'value[live]',
+            ],
+        ],
         'live_secret_key' => [
             'label' => 'lang:igniter.payregister::default.stripe.label_live_secret_key',
             'type' => 'text',
@@ -36,14 +46,14 @@ return [
                 'condition' => 'value[live]',
             ],
         ],
-        'live_publishable_key' => [
-            'label' => 'lang:igniter.payregister::default.stripe.label_live_publishable_key',
+        'test_publishable_key' => [
+            'label' => 'lang:igniter.payregister::default.stripe.label_test_publishable_key',
             'type' => 'text',
             'span' => 'right',
             'trigger' => [
                 'action' => 'show',
                 'field' => 'transaction_mode',
-                'condition' => 'value[live]',
+                'condition' => 'value[test]',
             ],
         ],
         'test_secret_key' => [
@@ -56,14 +66,16 @@ return [
                 'condition' => 'value[test]',
             ],
         ],
-        'test_publishable_key' => [
-            'label' => 'lang:igniter.payregister::default.stripe.label_test_publishable_key',
+        'webhook' => [
             'type' => 'text',
-            'span' => 'right',
+            'default' => md5(random_bytes(32)),
             'trigger' => [
                 'action' => 'show',
                 'field' => 'transaction_mode',
-                'condition' => 'value[test]',
+            ],
+            'attributes' => [
+                'readonly' => true,
+                'hidden' => true,
             ],
         ],
         'locale_code' => [

--- a/payments/stripe/fields.php
+++ b/payments/stripe/fields.php
@@ -46,8 +46,8 @@ return [
                 'condition' => 'value[live]',
             ],
         ],
-        'test_publishable_key' => [
-            'label' => 'lang:igniter.payregister::default.stripe.label_test_publishable_key',
+        'test_webhook_secret' => [
+            'label' => 'lang:igniter.payregister::default.stripe.label_test_webhook_secret',
             'type' => 'text',
             'span' => 'right',
             'trigger' => [
@@ -66,22 +66,20 @@ return [
                 'condition' => 'value[test]',
             ],
         ],
-        'webhook' => [
+        'live_webhook_secret' => [
+            'label' => 'lang:igniter.payregister::default.stripe.label_live_webhook_secret',
             'type' => 'text',
-            'default' => md5(random_bytes(32)),
+            'span' => 'left',
             'trigger' => [
                 'action' => 'show',
                 'field' => 'transaction_mode',
-            ],
-            'attributes' => [
-                'readonly' => true,
-                'hidden' => true,
+                'condition' => 'value[live]',
             ],
         ],
         'locale_code' => [
             'label' => 'lang:igniter.payregister::default.stripe.label_locale_code',
             'type' => 'text',
-            'span' => 'left',
+            'span' => 'right',
         ],
         'order_fee_type' => [
             'label' => 'lang:igniter.payregister::default.label_order_fee_type',
@@ -122,6 +120,8 @@ return [
         ['live_publishable_key', 'lang:igniter.payregister::default.stripe.label_live_publishable_key', 'string'],
         ['test_secret_key', 'lang:igniter.payregister::default.stripe.label_test_secret_key', 'string'],
         ['test_publishable_key', 'lang:igniter.payregister::default.stripe.label_test_publishable_key', 'string'],
+        ['test_webhook_secret', 'lang:igniter.payregister::default.stripe.label_test_webhook_secret', 'string'],
+        ['live_webhook_secret', 'lang:igniter.payregister::default.stripe.label_live_webhook_secret', 'string'],
         ['order_fee_type', 'lang:igniter.payregister::default.label_order_fee_type', 'integer'],
         ['order_fee', 'lang:igniter.payregister::default.label_order_fee', 'numeric'],
         ['order_total', 'lang:igniter.payregister::default.label_order_total', 'numeric'],

--- a/payments/stripe/info.blade.php
+++ b/payments/stripe/info.blade.php
@@ -1,17 +1,11 @@
 <div class="mt-3 p-3 border rounded">
     <h5>Configure Webhook</h5>
-    @if (is_null($formModel->getWebhook()))
-    <div>
-        Click the <b>Save</b> button to generate a webhook url.
-    </div>
-    @else
     <div>
         You can configure the webhook url <code>
-            <?= site_url('ti_payregister/'.$formModel->getWebhook().'/handle') ?>
+            {{ site_url('ti_payregister/stripe_webhook/handle') }}
         </code>in your <a
             target="_blank"
             href="https://dashboard.stripe.com/webhooks"
         >Stripe Dashboard > Developers > Webhooks</a>
     </div>
-    @endif
 </div>

--- a/payments/stripe/info.blade.php
+++ b/payments/stripe/info.blade.php
@@ -1,11 +1,17 @@
 <div class="mt-3 p-3 border rounded">
     <h5>Configure Webhook</h5>
+    @if (is_null($formModel->getWebhook()))
+    <div>
+        Click the <b>Save</b> button to generate a webhook url.
+    </div>
+    @else
     <div>
         You can configure the webhook url <code>
-            <?= site_url('ti_payregister/stripe_webhook/handle') ?>
+            <?= site_url('ti_payregister/'.$formModel->getWebhook().'/handle') ?>
         </code>in your <a
             target="_blank"
             href="https://dashboard.stripe.com/webhooks"
         >Stripe Dashboard > Developers > Webhooks</a>
     </div>
+    @endif
 </div>


### PR DESCRIPTION
It is highly recommended to keep the stripe callback URL a secret. Thus it is important to make the URL generated, so that every deployment of the website will get a different URL.

This change also included a minor adjustment on the stripe setting page to move the `Publication key` field before the `Secret key`, which preserves the order it shows on stripe console.

![image](https://user-images.githubusercontent.com/12481493/187093001-28d571f4-f6d9-408b-a0fd-43c70be1bccd.png)
