### PR TITLE
Google / Apple Pay is here! Stripe Checkout supported

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -33,6 +33,11 @@ class Extension extends BaseExtension
                 'name' => 'lang:igniter.payregister::default.stripe.text_payment_title',
                 'description' => 'lang:igniter.payregister::default.stripe.text_payment_desc',
             ],
+            \Igniter\PayRegister\Payments\StripeCheckout::class => [
+                'code' => 'stripecheckout',
+                'name' => 'lang:igniter.payregister::default.stripecheckout.text_payment_title',
+                'description' => 'lang:igniter.payregister::default.stripecheckout.text_payment_desc',
+            ],
             \Igniter\PayRegister\Payments\Mollie::class => [
                 'code' => 'mollie',
                 'name' => 'lang:igniter.payregister::default.mollie.text_payment_title',

--- a/language/en/default.php
+++ b/language/en/default.php
@@ -123,6 +123,35 @@ return [
         'help_locale_code' => 'See <a href="https://stripe.com/docs/js/appendix/supported_locales">Stripe.js supported locales</a',
     ],
 
+    'stripecheckout' => [
+        'text_tab_general' => 'General',
+        'text_payment_title' => 'Stripe Checkout',
+        'text_payment_desc' => 'Accept credit card, Apple Pay, Google Pay using Stripe builtin Checkout page',
+        'text_credit_or_debit' => 'Credit or debit card',
+
+        'text_auth_only' => 'Authorization Only',
+        'text_auth_capture' => 'Authorization & Capture',
+        'text_description' => 'Pay by Credit Card using Stripe',
+        'text_live' => 'Live',
+        'text_test' => 'Test',
+        'text_stripe_charge_description' => '%s Charge for %s',
+        'text_payment_status' => 'Payment %s (%s)',
+
+        'label_title' => 'Title',
+        'label_description' => 'Description',
+        'label_transaction_mode' => 'Transaction Mode',
+        'label_transaction_type' => 'Transaction Type',
+        'label_test_secret_key' => 'Test Secret Key',
+        'label_test_publishable_key' => 'Test Publishable Key',
+        'label_live_secret_key' => 'Live Secret Key',
+        'label_live_publishable_key' => 'Live Publishable Key',
+        'label_locale_code' => 'Locale Code',
+        'label_priority' => 'Priority',
+        'label_status' => 'Status',
+
+        'help_locale_code' => 'See <a href="https://stripe.com/docs/js/appendix/supported_locales">Stripe.js supported locales</a',
+    ],
+
     'mollie' => [
         'text_payment_title' => 'Mollie Payment',
         'text_payment_desc' => 'Accept credit card payments using Mollie API',

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -23,7 +23,7 @@ class Stripe extends BasePaymentGateway
     public function registerEntryPoints()
     {
         return [
-            // 'stripe_webhook' => 'processWebhookUrl',
+            'stripe_webhook' => 'processWebhookUrl',
         ];
     }
 

--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -23,7 +23,7 @@ class Stripe extends BasePaymentGateway
     public function registerEntryPoints()
     {
         return [
-            'stripe_webhook' => 'processWebhookUrl',
+            // 'stripe_webhook' => 'processWebhookUrl',
         ];
     }
 

--- a/payments/StripeCheckout.php
+++ b/payments/StripeCheckout.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Igniter\PayRegister\Payments;
+
+use Admin\Classes\BasePaymentGateway;
+use Admin\Models\Orders_model;
+use Exception;
+use Igniter\Flame\Exception\ApplicationException;
+use Igniter\Flame\Traits\EventEmitter;
+use Igniter\PayRegister\Traits\PaymentHelpers;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Str;
+use Stripe\StripeClient;
+
+class StripeCheckout extends BasePaymentGateway
+{
+    use EventEmitter;
+    use PaymentHelpers;
+
+    public function registerEntryPoints()
+    {
+        return [
+            'stripe_webhook' => 'processWebhookUrl',
+            'stripe_checkout_return_url' => 'processSuccessUrl',
+            'stripe_checkout_cancel_url' => 'processCancelUrl',
+        ];
+    }
+
+    public function isTestMode()
+    {
+        return $this->model->transaction_mode != 'live';
+    }
+
+    public function getPublishableKey()
+    {
+        return $this->isTestMode() ? $this->model->test_publishable_key : $this->model->live_publishable_key;
+    }
+
+    public function getSecretKey()
+    {
+        return $this->isTestMode() ? $this->model->test_secret_key : $this->model->live_secret_key;
+    }
+
+    public function shouldAuthorizePayment()
+    {
+        return $this->model->transaction_type == 'auth_only';
+    }
+
+    public function isApplicable($total, $host)
+    {
+        return $host->order_total <= $total;
+    }
+
+    /**
+     * @param array $data
+     * @param \Admin\Models\Payments_model $host
+     * @param \Admin\Models\Orders_model $order
+     *
+     * @return mixed
+     */
+    public function processPaymentForm($data, $host, $order)
+    {
+        $this->validatePaymentMethod($order, $host);
+
+        $fields = $this->getPaymentFormFields($order, $data);
+
+        try {
+            $gateway = $this->createGateway();
+            $response = $gateway->checkout->sessions->create($fields);
+
+            return Redirect::to($response->url);
+        } catch (Exception $ex) {
+            $order->logPaymentAttempt('Payment error -> '.$ex->getMessage(), 0, $fields, []);
+            throw new ApplicationException('Sorry, there was an error processing your payment. Please try again later.');
+        }
+    }
+
+    public function processSuccessUrl($params)
+    {
+        $hash = $params[0] ?? null;
+        $redirectPage = input('redirect');
+        $cancelPage = input('cancel');
+
+        $order = $this->createOrderModel()->whereHash($hash)->first();
+
+        try {
+            if (!$hash || !$order instanceof Orders_model)
+                throw new ApplicationException('No order found');
+
+            if (!strlen($redirectPage))
+                throw new ApplicationException('No redirect page found');
+
+            if (!strlen($cancelPage))
+                throw new ApplicationException('No cancel page found');
+
+            $paymentMethod = $order->payment_method;
+            if (!$paymentMethod || $paymentMethod->getGatewayClass() != static::class)
+                throw new ApplicationException('No valid payment method found');
+
+            $order->logPaymentAttempt('Payment successful', 1, [], $paymentMethod, true);
+            $order->updateOrderStatus($paymentMethod->order_status, ['notify' => false]);
+            $order->markAsPaymentProcessed();
+
+            return Redirect::to(page_url($redirectPage, [
+                'id' => $order->getKey(),
+                'hash' => $order->hash,
+            ]));
+        } catch (Exception $ex) {
+            $order->logPaymentAttempt('Payment error -> '.$ex->getMessage(), 0, [], []);
+            flash()->warning($ex->getMessage())->important();
+        }
+
+        return Redirect::to(page_url($cancelPage));
+    }
+
+    public function processCancelUrl($params)
+    {
+        $hash = $params[0] ?? null;
+        $order = $this->createOrderModel()->whereHash($hash)->first();
+        if (!$hash || !$order instanceof Orders_model)
+            throw new ApplicationException('No order found');
+
+        if (!strlen($redirectPage = input('redirect')))
+            throw new ApplicationException('No redirect page found');
+
+        $paymentMethod = $order->payment_method;
+        if (!$paymentMethod || $paymentMethod->getGatewayClass() != static::class)
+            throw new ApplicationException('No valid payment method found');
+
+        $order->logPaymentAttempt('Payment canceled by customer', 0, input());
+
+        return Redirect::to(page_url($redirectPage));
+    }
+
+    protected function createGateway()
+    {
+        \Stripe\Stripe::setAppInfo(
+            'TastyIgniter Stripe',
+            '1.0.0',
+            'https://tastyigniter.com/marketplace/item/igniter-payregister',
+            'pp_partner_JZyCCGR3cOwj9S' // Used by Stripe to identify this integration
+        );
+
+        $stripeClient = new StripeClient([
+            'api_key' => $this->getSecretKey(),
+        ]);
+
+        $this->fireSystemEvent('payregister.stripe.extendClient', [$stripeClient]);
+
+        return $stripeClient;
+    }
+
+    protected function getPaymentFormFields($order, $data = [])
+    {
+        $cancelUrl = $this->makeEntryPointUrl('stripe_checkout_cancel_url').'/'.$order->hash;
+        $successUrl = $this->makeEntryPointUrl('stripe_checkout_return_url').'/'.$order->hash;
+        $successUrl .= '?redirect='.array_get($data, 'successPage').'&cancel='.array_get($data, 'cancelPage');
+
+        $fields = [
+            'line_items' => [
+                [
+                    'price_data' => [
+                        'currency' => currency()->getUserCurrency(),
+                        // All amounts sent to Stripe must be in integers, representing the lowest currency unit (cents)
+                        'unit_amount_decimal' => number_format($order->order_total, 2, '.', '') * 100,
+                        'product_data' => [
+                            'name' => 'Test',
+                        ],
+                    ],
+                    'quantity' => 1,
+                ],
+            ],
+            'cancel_url' => $cancelUrl.'?redirect='.array_get($data, 'cancelPage'),
+            'success_url' => $successUrl,
+            'mode' => 'payment',
+            'metadata' => [
+                'order_id' => $order->order_id,
+            ],
+        ];
+
+        $this->fireSystemEvent('payregister.stripecheckout.extendFields', [&$fields, $order, $data]);
+
+        return $fields;
+    }
+
+    public function processWebhookUrl()
+    {
+        if (strtolower(request()->method()) !== 'post')
+            return response('Request method must be POST', 400);
+
+        $payload = json_decode(request()->getContent(), true);
+        if (!isset($payload['type']) || !strlen($eventType = $payload['type']))
+            return response('Missing webhook event name', 400);
+
+        $eventName = Str::studly(str_replace('.', '_', $eventType));
+        $methodName = 'webhookHandle'.$eventName;
+
+        if (method_exists($this, $methodName))
+            $this->$methodName($payload);
+
+        Event::fire('payregister.stripecheckout.webhook.handle'.$eventName, [$payload]);
+
+        return response('Webhook Handled');
+    }
+
+    protected function webhookHandleCheckoutSessionCompleted($payload)
+    {
+        if ($order = Orders_model::find($payload['data']['object']['metadata']['order_id'])) {
+            if (!$order->isPaymentProcessed()) {
+                if ($payload['data']['object']['status'] === 'requires_capture') {
+                    $order->logPaymentAttempt('Payment authorized', 1, [], $payload['data']['object']);
+                } else {
+                    $order->logPaymentAttempt('Payment successful', 1, [], $payload['data']['object'], true);
+                }
+
+                $order->updateOrderStatus($this->model->order_status, ['notify' => false]);
+                $order->markAsPaymentProcessed();
+            }
+        }
+    }
+}

--- a/payments/StripeCheckout.php
+++ b/payments/StripeCheckout.php
@@ -165,7 +165,7 @@ class StripeCheckout extends BasePaymentGateway
                         // All amounts sent to Stripe must be in integers, representing the lowest currency unit (cents)
                         'unit_amount_decimal' => number_format($order->order_total, 2, '.', '') * 100,
                         'product_data' => [
-                            'name' => 'Test',
+                            'name' => 'Meals',
                         ],
                     ],
                     'quantity' => 1,
@@ -177,6 +177,7 @@ class StripeCheckout extends BasePaymentGateway
             'metadata' => [
                 'order_id' => $order->order_id,
             ],
+            'customer_email' => array_get($data, 'email'),
         ];
 
         $this->fireSystemEvent('payregister.stripecheckout.extendFields', [&$fields, $order, $data]);

--- a/payments/StripeCheckout.php
+++ b/payments/StripeCheckout.php
@@ -21,7 +21,7 @@ class StripeCheckout extends BasePaymentGateway
     public function registerEntryPoints()
     {
         return [
-            'stripe_webhook' => 'processWebhookUrl',
+            'stripe_checkout_webhook' => 'processWebhookUrl',
             'stripe_checkout_return_url' => 'processSuccessUrl',
             'stripe_checkout_cancel_url' => 'processCancelUrl',
         ];

--- a/payments/StripeCheckout.php
+++ b/payments/StripeCheckout.php
@@ -177,8 +177,18 @@ class StripeCheckout extends BasePaymentGateway
             'metadata' => [
                 'order_id' => $order->order_id,
             ],
-            'customer_email' => array_get($data, 'email'),
         ];
+
+        
+        // Share the email field in our form to Stripe checkout session,
+        // so customers don't need to enter twice
+        if (!is_null(array_get($data, 'email'))) {
+            // if is unregistered customer
+            $fields['customer_email'] = array_get($data, 'email');
+        } elseif (!is_null($order->customer) && !is_null($order->customer->email)) {
+            // else if is registered, get email from customer profile
+            $fields['customer_email'] = $order->customer->email;
+        }
 
         $this->fireSystemEvent('payregister.stripecheckout.extendFields', [&$fields, $order, $data]);
 

--- a/payments/stripecheckout/fields.php
+++ b/payments/stripecheckout/fields.php
@@ -1,0 +1,118 @@
+<?php
+
+return [
+    'fields' => [
+        'setup' => [
+            'type' => 'partial',
+            'path' => '$/igniter/payregister/payments/stripecheckout/info',
+        ],
+        'transaction_mode' => [
+            'label' => 'lang:igniter.payregister::default.stripecheckout.label_transaction_mode',
+            'type' => 'radiotoggle',
+            'default' => 'test',
+            'span' => 'left',
+            'options' => [
+                'live' => 'lang:igniter.payregister::default.stripecheckout.text_live',
+                'test' => 'lang:igniter.payregister::default.stripecheckout.text_test',
+            ],
+        ],
+        'transaction_type' => [
+            'label' => 'lang:igniter.payregister::default.stripecheckout.label_transaction_type',
+            'type' => 'radiotoggle',
+            'default' => 'auth_capture',
+            'span' => 'right',
+            'options' => [
+                'auth_capture' => 'lang:igniter.payregister::default.stripecheckout.text_auth_capture',
+                'auth_only' => 'lang:igniter.payregister::default.stripecheckout.text_auth_only',
+            ],
+        ],
+        'live_secret_key' => [
+            'label' => 'lang:igniter.payregister::default.stripecheckout.label_live_secret_key',
+            'type' => 'text',
+            'span' => 'left',
+            'trigger' => [
+                'action' => 'show',
+                'field' => 'transaction_mode',
+                'condition' => 'value[live]',
+            ],
+        ],
+        'live_publishable_key' => [
+            'label' => 'lang:igniter.payregister::default.stripecheckout.label_live_publishable_key',
+            'type' => 'text',
+            'span' => 'right',
+            'trigger' => [
+                'action' => 'show',
+                'field' => 'transaction_mode',
+                'condition' => 'value[live]',
+            ],
+        ],
+        'test_secret_key' => [
+            'label' => 'lang:igniter.payregister::default.stripecheckout.label_test_secret_key',
+            'type' => 'text',
+            'span' => 'left',
+            'trigger' => [
+                'action' => 'show',
+                'field' => 'transaction_mode',
+                'condition' => 'value[test]',
+            ],
+        ],
+        'test_publishable_key' => [
+            'label' => 'lang:igniter.payregister::default.stripecheckout.label_test_publishable_key',
+            'type' => 'text',
+            'span' => 'right',
+            'trigger' => [
+                'action' => 'show',
+                'field' => 'transaction_mode',
+                'condition' => 'value[test]',
+            ],
+        ],
+        'locale_code' => [
+            'label' => 'lang:igniter.payregister::default.stripecheckout.label_locale_code',
+            'type' => 'text',
+            'span' => 'left',
+        ],
+        'order_fee_type' => [
+            'label' => 'lang:igniter.payregister::default.label_order_fee_type',
+            'type' => 'radiotoggle',
+            'span' => 'right',
+            'cssClass' => 'flex-width',
+            'default' => 1,
+            'options' => [
+                1 => 'lang:admin::lang.menus.text_fixed_amount',
+                2 => 'lang:admin::lang.menus.text_percentage',
+            ],
+        ],
+        'order_fee' => [
+            'label' => 'lang:igniter.payregister::default.label_order_fee',
+            'type' => 'currency',
+            'span' => 'right',
+            'cssClass' => 'flex-width',
+            'default' => 0,
+            'comment' => 'lang:igniter.payregister::default.help_order_fee',
+        ],
+        'order_total' => [
+            'label' => 'lang:igniter.payregister::default.label_order_total',
+            'type' => 'currency',
+            'span' => 'left',
+            'comment' => 'lang:igniter.payregister::default.help_order_total',
+        ],
+        'order_status' => [
+            'label' => 'lang:igniter.payregister::default.label_order_status',
+            'type' => 'select',
+            'options' => [\Admin\Models\Statuses_model::class, 'getDropdownOptionsForOrder'],
+            'span' => 'right',
+            'comment' => 'lang:igniter.payregister::default.help_order_status',
+        ],
+    ],
+    'rules' => [
+        ['transaction_mode', 'lang:igniter.payregister::default.stripecheckout.label_transaction_mode', 'string'],
+        ['live_secret_key', 'lang:igniter.payregister::default.stripecheckout.label_live_secret_key', 'string'],
+        ['live_publishable_key', 'lang:igniter.payregister::default.stripecheckout.label_live_publishable_key', 'string'],
+        ['test_secret_key', 'lang:igniter.payregister::default.stripecheckout.label_test_secret_key', 'string'],
+        ['test_publishable_key', 'lang:igniter.payregister::default.stripecheckout.label_test_publishable_key', 'string'],
+        ['order_fee_type', 'lang:igniter.payregister::default.label_order_fee_type', 'integer'],
+        ['order_fee', 'lang:igniter.payregister::default.label_order_fee', 'numeric'],
+        ['order_total', 'lang:igniter.payregister::default.label_order_total', 'numeric'],
+        ['order_status', 'lang:igniter.payregister::default.label_order_status', 'integer'],
+    ],
+];

--- a/payments/stripecheckout/info.blade.php
+++ b/payments/stripecheckout/info.blade.php
@@ -1,0 +1,11 @@
+<div class="mt-3 p-3 border rounded">
+    <h5>Configure Webhook</h5>
+    <div>
+        You can configure the webhook url <code>
+            <?= site_url('ti_payregister/stripe_webhook/handle') ?>
+        </code>in your <a
+            target="_blank"
+            href="https://dashboard.stripe.com/webhooks"
+        >Stripe Dashboard > Developers > Webhooks</a>
+    </div>
+</div>

--- a/payments/stripecheckout/info.blade.php
+++ b/payments/stripecheckout/info.blade.php
@@ -2,7 +2,7 @@
     <h5>Configure Webhook</h5>
     <div>
         You can configure the webhook url <code>
-            <?= site_url('ti_payregister/stripe_webhook/handle') ?>
+            <?= site_url('ti_payregister/stripe_checkout_webhook/handle') ?>
         </code>in your <a
             target="_blank"
             href="https://dashboard.stripe.com/webhooks"


### PR DESCRIPTION
[Stripe Checkout](https://stripe.com/payments/checkout) is the checkout page built by Stripe. It is an off-site checkout procedure similar to Paypal Express. The off-site checkout procedure means the user will be directed to another page for completing the checkout.

I'm more than happy to make this an open-source contribution instead of a paid extension.

![image](https://user-images.githubusercontent.com/12481493/187943172-da45eb87-8d49-4fdc-869a-594cc688bb75.png)
(A little bonus here is Wechat Pay 微信支付 and Alipay 支付宝 can also be supported with stripe checkout!)

### Pros & Cons compared to the existing stripe payment method
#### Pros
 - Of course, Google / Apple Pay is supported. 
 - And a benefit that may not be very obvious is you don't need a [verification of your domain](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements#apple-pay-and-google-pay) at Apple! Stripe has already handled that for you.
 - Feeling more secure from customers' perspective. Some customers are very cautious about entering credit card information on a non-well-known website. Now they can feel more at ease because they are entering their credentials at a Stripe.com website.

#### Cons
The payment credential cannot be saved to the user profile. If your website has a lot of repeat visitors that have registered and saved their credit cards on the site, the existing Stripe payment should be a better fit for you.
However, compared to paying with the "saved payment profile", there would be only two more clicks if the customer is using Google/Apple pay at the stripe checkout page. Moreover, the Stripe Checkout also provides a "Remember my payment info" feature, which basically auto-fills the customer's credit card information after a simple verification.


### ~~Potentially blocked by https://github.com/tastyigniter/ti-ext-payregister/pull/42~~
<s>The feature is almost complete though with a workaround that [disabled the callback of existing stripe payment](https://github.com/philipxyc/ti-ext-payregister/blob/577c0dfe7a0d6cdc136ad18a75aa21ebc61c54e8/payments/Stripe.php#L26). It can be very easily replaced with a more elegant workaround that gives two Stripe extensions different **fixed** callback URL. But I would still advocate making the callback URL a secret by including a random hash in it.
</s>

Please let me know if is there anything I can improve here. Thanks!
