### PR TITLE
replace Omnipay Square handling with square/square php SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "tastyigniter",
     "paypal",
     "stripe",
+    "square",
     "payment",
     "gateway",
     "authorizenet",
@@ -24,7 +25,7 @@
     "omnipay/paypal": "~3.0",
     "stripe/stripe-php": "~7.93.0",
     "omnipay/mollie": "~5.1",
-    "sampoyigi/omnipay-square": "~2.0"
+    "square/square": "25.1.0.20230119"
   },
   "extra": {
     "tastyigniter-extension": {

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -7,11 +7,9 @@ use Exception;
 use Igniter\Flame\Exception\ApplicationException;
 use Igniter\Flame\Traits\EventEmitter;
 use Igniter\PayRegister\Traits\PaymentHelpers;
-
+use Square\Environment;
 use Square\Models;
 use Square\SquareClient;
-use Square\Environment;
-use Square\Exceptions\ApiException;
 
 class Square extends BasePaymentGateway
 {
@@ -67,7 +65,7 @@ class Square extends BasePaymentGateway
         return true;
     }
 
-    public function createPayment($fields, $order, $host){
+    public function createPayment($fields, $order, $host) {
         try {
 
             $client = $this->createClient();
@@ -85,24 +83,21 @@ class Square extends BasePaymentGateway
                 $body_amountMoney
             );
 
-
-            if( isset($fields['tip']) ){
+            if(isset($fields['tip'])){
                 $body_tipMoney = new Models\Money();
                 $body_tipMoney->setAmount($fields['tip'] * 100);
                 $body_tipMoney->setCurrency($fields['currency']);
                 $body->setTipMoney($body_tipMoney);
             }
-            
-
 
             $body->setAutocomplete(true);
-            if( isset($fields['customerReference'])){
+            if(isset($fields['customerReference'])){
                 $body->setCustomerId($fields['customerReference']);
             }
-            if( isset($fields['token'])){
+            if(isset($fields['token'])){
                 $body->setVerificationToken($fields['token']);
             }
-            
+
             $body->setLocationId($this->getLocationId());
             $body->setReferenceId($fields['referenceId']);
             $body->setNote($order->getCustomerNameAttribute(''));
@@ -132,7 +127,6 @@ class Square extends BasePaymentGateway
 
         $fields = $this->getPaymentFormFields($order, $data);
 
-
         if (array_get($data, 'create_payment_profile', 0) == 1 && $order->customer) {
             $profile = $this->updatePaymentProfile($order->customer, $data);
             $fields['sourceId'] = array_get($profile->profile_data, 'card_id');
@@ -144,7 +138,7 @@ class Square extends BasePaymentGateway
         }
 
         $this->createPayment($fields, $order, $host);
-        
+
     }
 
     //
@@ -206,10 +200,10 @@ class Square extends BasePaymentGateway
 
             $response = $customersApi->retrieveCustomer(array_get($profileData, 'customer_id'));
 
-            if ( !$response->isSuccess() ) {
+            if (!$response->isSuccess()) {
                 $newCustomerRequired = true;
-            } 
-                
+            }
+
         }
 
         if ($newCustomerRequired) {
@@ -219,14 +213,14 @@ class Square extends BasePaymentGateway
             $body->setFamilyName($customer->last_name);
             $body->setEmailAddress($customer->email);
 
-            $body->setReferenceId('SqCustRef#' . $customer->customer_id);
+            $body->setReferenceId('SqCustRef#'.$customer->customer_id);
 
             $response = $customersApi->createCustomer($body);
 
             if (!$response->isSuccess()) {
                 $errors = $response->getErrors();
                 $errors = $errors[0]->getDetail();
-                throw new ApplicationException('Square Customer Create Error: ' . $errors);
+                throw new ApplicationException('Square Customer Create Error: '.$errors);
             }
 
             
@@ -253,14 +247,14 @@ class Square extends BasePaymentGateway
             if (!$response->isSuccess()) {
                 $newCardRequired = true;
             } 
-                
+
         }
 
         if ($newCardRequired) {
 
             $body_card = new Models\Card();
 
-            $body_card->setCardholderName($data['first_name'] . ' ' . $data['last_name']);
+            $body_card->setCardholderName($data['first_name'].' '.$data['last_name']);
             $body_card->setCustomerId($customerId);
             $body_card->setReferenceId($referenceId);
 
@@ -270,14 +264,13 @@ class Square extends BasePaymentGateway
                 $body_card
             );
 
-
             $response = $cardsApi->createCard($body);
 
             if (!$response->isSuccess()) {
                 $errors = $response->getErrors();
                 $errors = $errors[0]->getDetail();
 
-                throw new ApplicationException('Square Create Payment Card Error ' . $errors);
+                throw new ApplicationException('Square Create Payment Card Error '.$errors);
             } 
                 
         }
@@ -309,8 +302,6 @@ class Square extends BasePaymentGateway
      */
     protected function deletePaymentProfileData($profile)
     {
-
-        
         $profile->setProfileData([]);
 
         return $profile;
@@ -430,12 +421,10 @@ class Square extends BasePaymentGateway
             $errors = $response->getErrors();
             $errors = $errors[0]->getDetail();
 
-            throw new ApplicationException('Square Delete Payment Card Error ' . $errors);
+            throw new ApplicationException('Square Delete Payment Card Error '.$errors);
         } 
 
-        
         $this->deletePaymentProfileData($profile);
-        
 
     }
 }

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -271,7 +271,7 @@ class Square extends BasePaymentGateway
 
                 throw new ApplicationException('Square Create Payment Card Error '.$errors);
             }
-   
+
         }
 
         return $response->getResult();

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -223,7 +223,6 @@ class Square extends BasePaymentGateway
                 throw new ApplicationException('Square Customer Create Error: '.$errors);
             }
 
-            
         }
 
         return $response->getResult();
@@ -246,7 +245,7 @@ class Square extends BasePaymentGateway
 
             if (!$response->isSuccess()) {
                 $newCardRequired = true;
-            } 
+            }
 
         }
 
@@ -271,8 +270,8 @@ class Square extends BasePaymentGateway
                 $errors = $errors[0]->getDetail();
 
                 throw new ApplicationException('Square Create Payment Card Error '.$errors);
-            } 
-                
+            }
+   
         }
 
         return $response->getResult();
@@ -372,7 +371,7 @@ class Square extends BasePaymentGateway
         else {
             $errors = $response->getErrors();
             $errors = $errors[0]->getDetail();
-            $order->logPaymentAttempt('Payment error -> '. $errors, 0, $fields, $response->getResult());
+            $order->logPaymentAttempt('Payment error -> '.$errors, 0, $fields, $response->getResult());
             throw new Exception($errors);
         }
     }
@@ -395,7 +394,6 @@ class Square extends BasePaymentGateway
         if (!$profile)
             $profile = $this->model->initPaymentProfile($customer);
 
-        
         $this->updatePaymentProfileData($profile, [
             'customer_id' => $customerId,
             'card_id' => $cardId,
@@ -404,12 +402,10 @@ class Square extends BasePaymentGateway
         return $profile;
     }
 
-
     protected function handleDeletePaymentProfile($customer, $profile)
     {
         if (!isset($profile->profile_data['customer_id']))
             return;
-
 
         $cardId = $profile['profile_data']['card_id'];
         $client = $this->createClient();
@@ -422,7 +418,7 @@ class Square extends BasePaymentGateway
             $errors = $errors[0]->getDetail();
 
             throw new ApplicationException('Square Delete Payment Card Error '.$errors);
-        } 
+        }
 
         $this->deletePaymentProfileData($profile);
 

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -421,7 +421,6 @@ class Square extends BasePaymentGateway
 
 
         $cardId = $profile['profile_data']['card_id'];
-        Log::info($profile);
         $client = $this->createClient();
         $cardsApi = $client->getCardsApi();
 

--- a/payments/Square.php
+++ b/payments/Square.php
@@ -7,7 +7,11 @@ use Exception;
 use Igniter\Flame\Exception\ApplicationException;
 use Igniter\Flame\Traits\EventEmitter;
 use Igniter\PayRegister\Traits\PaymentHelpers;
-use Omnipay\Omnipay;
+
+use Square\Models;
+use Square\SquareClient;
+use Square\Environment;
+use Square\Exceptions\ApiException;
 
 class Square extends BasePaymentGateway
 {
@@ -63,6 +67,56 @@ class Square extends BasePaymentGateway
         return true;
     }
 
+    public function createPayment($fields, $order, $host){
+        try {
+
+            $client = $this->createClient();
+            $paymentsApi = $client->getPaymentsApi();
+
+            $body_idempotencyKey = md5(rand());
+
+            $body_amountMoney = new Models\Money();
+            $body_amountMoney->setAmount($fields['amount'] * 100);
+            $body_amountMoney->setCurrency($fields['currency']);
+
+            $body = new Models\CreatePaymentRequest(
+                $fields['sourceId'],
+                md5(rand()), // idempotency key
+                $body_amountMoney
+            );
+
+
+            if( isset($fields['tip']) ){
+                $body_tipMoney = new Models\Money();
+                $body_tipMoney->setAmount($fields['tip'] * 100);
+                $body_tipMoney->setCurrency($fields['currency']);
+                $body->setTipMoney($body_tipMoney);
+            }
+            
+
+
+            $body->setAutocomplete(true);
+            if( isset($fields['customerReference'])){
+                $body->setCustomerId($fields['customerReference']);
+            }
+            if( isset($fields['token'])){
+                $body->setVerificationToken($fields['token']);
+            }
+            
+            $body->setLocationId($this->getLocationId());
+            $body->setReferenceId($fields['referenceId']);
+            $body->setNote($order->getCustomerNameAttribute(''));
+
+            $response = $paymentsApi->createPayment($body);
+
+            $this->handlePaymentResponse($response, $order, $host, $fields);
+        }
+        catch (Exception $ex) {
+            $order->logPaymentAttempt('Payment error -> '.$ex->getMessage(), 0, $fields, []);
+            throw new ApplicationException('Sorry, there was an error processing your payment. Please try again later');
+        }
+    }
+
     /**
      * Processes payment using passed data.
      *
@@ -78,26 +132,19 @@ class Square extends BasePaymentGateway
 
         $fields = $this->getPaymentFormFields($order, $data);
 
+
         if (array_get($data, 'create_payment_profile', 0) == 1 && $order->customer) {
             $profile = $this->updatePaymentProfile($order->customer, $data);
-            $fields['customerCardId'] = array_get($profile->profile_data, 'card_id');
+            $fields['sourceId'] = array_get($profile->profile_data, 'card_id');
             $fields['customerReference'] = array_get($profile->profile_data, 'customer_id');
         }
         else {
-            $fields['nonce'] = array_get($data, 'square_card_nonce');
+            $fields['sourceId'] = array_get($data, 'square_card_nonce');
             $fields['token'] = array_get($data, 'square_card_token');
         }
 
-        try {
-            $gateway = $this->createGateway();
-            $response = $gateway->purchase($fields)->send();
-
-            $this->handlePaymentResponse($response, $order, $host, $fields);
-        }
-        catch (Exception $ex) {
-            $order->logPaymentAttempt('Payment error -> '.$ex->getMessage(), 0, $fields, []);
-            throw new ApplicationException('Sorry, there was an error processing your payment. Please try again later.');
-        }
+        $this->createPayment($fields, $order, $host);
+        
     }
 
     //
@@ -140,82 +187,102 @@ class Square extends BasePaymentGateway
             throw new ApplicationException('Payment profile not found');
 
         $fields = $this->getPaymentFormFields($order, $data);
-        $fields['customerCardId'] = array_get($profile->profile_data, 'card_id');
+        $fields['sourceId'] = array_get($profile->profile_data, 'card_id');
         $fields['customerReference'] = array_get($profile->profile_data, 'customer_id');
 
-        try {
-            $gateway = $this->createGateway();
-            $response = $gateway->purchase($fields)->send();
+        $this->createPayment($fields, $order, $host);
 
-            $this->handlePaymentResponse($response, $order, $host, $fields);
-        }
-        catch (Exception $ex) {
-            $order->logPaymentAttempt('Payment error -> '.$ex->getMessage(), 0, $fields, []);
-            throw new ApplicationException('Sorry, there was an error processing your payment. Please try again later.');
-        }
     }
 
     protected function createOrFetchCustomer($profileData, $customer)
     {
         $response = false;
-        $gateway = $this->createGateway();
+        $client = $this->createClient();
+        $customersApi = $client->getCustomersApi();
+
         $newCustomerRequired = !array_get($profileData, 'customer_id');
 
         if (!$newCustomerRequired) {
-            $response = $gateway->fetchCustomer([
-                'customerReference' => array_get($profileData, 'customer_id'),
-            ])->send();
 
-            if (!$response->isSuccessful())
+            $response = $customersApi->retrieveCustomer(array_get($profileData, 'customer_id'));
+
+            if ( !$response->isSuccess() ) {
                 $newCustomerRequired = true;
+            } 
+                
         }
 
         if ($newCustomerRequired) {
-            $response = $gateway->createCustomer([
-                'firstName' => $customer->first_name,
-                'lastName' => $customer->last_name,
-                'email' => $customer->email,
-            ])->send();
 
-            if (!$response->isSuccessful()) {
-                throw new ApplicationException($response->getMessage());
+            $body = new Models\CreateCustomerRequest();
+            $body->setGivenName($customer->first_name);
+            $body->setFamilyName($customer->last_name);
+            $body->setEmailAddress($customer->email);
+
+            $body->setReferenceId('SqCustRef#' . $customer->customer_id);
+
+            $response = $customersApi->createCustomer($body);
+
+            if (!$response->isSuccess()) {
+                $errors = $response->getErrors();
+                $errors = $errors[0]->getDetail();
+                throw new ApplicationException('Square Customer Create Error: ' . $errors);
             }
+
+            
         }
 
-        return $response;
+        return $response->getResult();
     }
 
-    protected function createOrFetchCard($customerId, $profileData, $data)
+    protected function createOrFetchCard($customerId, $referenceId, $profileData, $data)
     {
         $cardId = array_get($profileData, 'card_id');
         $nonce = array_get($data, 'square_card_nonce');
 
         $response = false;
-        $gateway = $this->createGateway();
+        $client = $this->createClient();
+        $cardsApi = $client->getCardsApi();
+
         $newCardRequired = !$cardId;
 
         if (!$newCardRequired) {
-            $response = $gateway->fetchCard([
-                'card' => $cardId,
-                'customerReference' => $customerId,
-            ])->send();
 
-            if (!$response->isSuccessful())
+            $response = $cardsApi->retrieveCard($cardId);
+
+            if (!$response->isSuccess()) {
                 $newCardRequired = true;
+            } 
+                
         }
 
         if ($newCardRequired) {
-            $response = $gateway->createCard([
-                'cardholderName' => array_get($data, 'first_name').' '.array_get($data, 'last_name'),
-                'customerReference' => $customerId,
-                'card' => $nonce,
-            ])->send();
 
-            if (!$response->isSuccessful())
-                throw new ApplicationException($response->getMessage());
+            $body_card = new Models\Card();
+
+            $body_card->setCardholderName($data['first_name'] . ' ' . $data['last_name']);
+            $body_card->setCustomerId($customerId);
+            $body_card->setReferenceId($referenceId);
+
+            $body = new Models\CreateCardRequest(
+                md5(rand()),
+                $nonce,
+                $body_card
+            );
+
+
+            $response = $cardsApi->createCard($body);
+
+            if (!$response->isSuccess()) {
+                $errors = $response->getErrors();
+                $errors = $errors[0]->getDetail();
+
+                throw new ApplicationException('Square Create Payment Card Error ' . $errors);
+            } 
+                
         }
 
-        return $response;
+        return $response->getResult();
     }
 
     /**
@@ -226,9 +293,25 @@ class Square extends BasePaymentGateway
      */
     protected function updatePaymentProfileData($profile, $profileData = [], $cardData = [])
     {
-        $profile->card_brand = strtolower(array_get($cardData, 'card.card_brand'));
-        $profile->card_last4 = array_get($cardData, 'card.last_4');
+
+        $profile->card_brand = strtolower($cardData->getCardBrand());
+        $profile->card_last4 = $cardData->getLast4();
         $profile->setProfileData($profileData);
+
+        return $profile;
+    }
+
+    /**
+     * @param \Admin\Models\Payment_profiles_model $profile
+     * @param array $profileData
+     * @param array $cardData
+     * @return \Admin\Models\Payment_profiles_model
+     */
+    protected function deletePaymentProfileData($profile)
+    {
+
+        
+        $profile->setProfileData([]);
 
         return $profile;
     }
@@ -238,34 +321,122 @@ class Square extends BasePaymentGateway
     //
 
     /**
-     * @return \Omnipay\Square\Gateway|\Omnipay\Common\GatewayInterface
+     * @return \Square\SquareClient
      */
-    protected function createGateway()
+    protected function createClient()
     {
-        $gateway = Omnipay::create('Square');
+        $client = new SquareClient([
+            'accessToken' => $this->getAccessToken(),
+            'environment' => $this->isTestMode() ? Environment::SANDBOX : Environment::PRODUCTION,
+        ]);
 
-        $gateway->setTestMode($this->isTestMode());
-        $gateway->setAppId($this->getAppId());
-        $gateway->setAccessToken($this->getAccessToken());
-        $gateway->setLocationId($this->getLocationId());
-
-        $this->fireSystemEvent('payregister.square.extendGateway', [$gateway]);
-
-        return $gateway;
+        return $client;
     }
 
     protected function getPaymentFormFields($order, $data = [])
     {
+
+        // just for Square - record tips as separate amount
+        $order_amt = $order->order_total;
+        $tip_amt = 0;
+        foreach($order->getOrderTotals() as $ot){
+            if($ot->code == 'tip'){
+                $tip_amt = $ot->value;
+                $order_amt -= $tip_amt;
+            }
+        }
+
         $fields = [
             'idempotencyKey' => uniqid(),
-            'amount' => number_format($order->order_total, 2, '.', ''),
+            'amount' => number_format($order_amt, 2, '.', ''),
             'currency' => currency()->getUserCurrency(),
             'note' => 'Payment for Order '.$order->order_id,
             'referenceId' => (string)$order->order_id,
         ];
 
+        if($tip_amt){
+            $fields['tip'] = number_format($tip_amt, 2, '.', '');
+        }
+
         $this->fireSystemEvent('payregister.square.extendFields', [&$fields, $order, $data]);
 
         return $fields;
+    }
+
+    /**
+     * @param \Square\Models\CretePaymentResponse $response
+     * @param \Admin\Models\Orders_model $order
+     * @param \Admin\Models\Payments_model $host
+     * @param $fields
+     * @return void
+     * @throws \Exception
+     */
+    protected function handlePaymentResponse($response, $order, $host, $fields, $isRefundable = false)
+    {
+        if ($response->isSuccess()) {
+            $order->logPaymentAttempt('Payment successful', 1, $fields, $response->getResult(), $isRefundable);
+            $order->updateOrderStatus($host->order_status, ['notify' => false]);
+            $order->markAsPaymentProcessed();
+        }
+        else {
+            $errors = $response->getErrors();
+            $errors = $errors[0]->getDetail();
+            $order->logPaymentAttempt('Payment error -> '. $errors, 0, $fields, $response->getResult());
+            throw new Exception($errors);
+        }
+    }
+
+    protected function handleUpdatePaymentProfile($customer, $data)
+    {
+        $profile = $this->model->findPaymentProfile($customer);
+        $profileData = $profile ? (array)$profile->profile_data : [];
+
+        $response = $this->createOrFetchCustomer($profileData, $customer);
+
+        $customerId = $response->getCustomer()->getId();
+        $referenceId = $response->getCustomer()->getReferenceId();
+
+        $response = $this->createOrFetchCard($customerId, $referenceId, $profileData, $data);
+
+        $cardData = $response->getCard();
+        $cardId = $response->getCard()->getId();
+
+        if (!$profile)
+            $profile = $this->model->initPaymentProfile($customer);
+
+        
+        $this->updatePaymentProfileData($profile, [
+            'customer_id' => $customerId,
+            'card_id' => $cardId,
+        ], $cardData);
+
+        return $profile;
+    }
+
+
+    protected function handleDeletePaymentProfile($customer, $profile)
+    {
+        if (!isset($profile->profile_data['customer_id']))
+            return;
+
+
+        $cardId = $profile['profile_data']['card_id'];
+        Log::info($profile);
+        $client = $this->createClient();
+        $cardsApi = $client->getCardsApi();
+
+        $response = $cardsApi->disableCard($cardId);
+
+        if (!$response->isSuccess()) {
+            $errors = $response->getErrors();
+            $errors = $errors[0]->getDetail();
+
+            throw new ApplicationException('Square Delete Payment Card Error ' . $errors);
+        } 
+
+        
+        $this->deletePaymentProfileData($profile);
+        
+
     }
 }


### PR DESCRIPTION
https://github.com/tastyigniter/ti-ext-payregister/issues/40 requires changed to vendor-ed code in order to log tip amounts in Square (which is necessary for tip-outs to staff when using Square as your payment platform). 

This PR drops the dependency on omnipay's square gateway, but adds a dependency on the square PHP SDK `square/square`. 

I've done some happy-path testing to confirm that the following work as expected on TI 3.6.1

- Payment for an order when not logged in
- Payment for order + Payment Profile saved with 'save this credit card' selected when logged in
- Payment for order with previously saved card
- Deletion of payment profile on checkout screen

I have a production environment that I can test this on as well, but it doesn't utilize payment profiles and will only really test the 'Payment for an order when not logged in' case. Frankly, I'm not too familiar with the payment profile code at all and some scrutiny would be appreciated. 





