### PR TITLE
Correct header name for Stripe webhook signature verification

### DIFF
--- a/payments/Stripe.php
+++ b/payments/Stripe.php
@@ -611,7 +611,7 @@ class Stripe extends BasePaymentGateway
 
         $event = \Stripe\Webhook::constructEvent(
             request()->getContent(),
-            request()->header('HTTP_STRIPE_SIGNATURE'),
+            request()->header('stripe-signature'),
             $webhookSecret
         );
 


### PR DESCRIPTION
### Summary

This PR fixes an issue with Stripe webhook signature verification in the `processWebhookUrl` method. The header name used to retrieve the Stripe signature was incorrect, causing signature verification failures.

### Details

- Updated the header name from `HTTP_STRIPE_SIGNATURE` to `stripe-signature` in the call to `Stripe\Webhook::constructEvent`.

```
Stripe\Exception\SignatureVerificationException: Unable to extract timestamp and signatures from header
in
extensions/igniter/payregister/vendor/stripe/stripe-php/lib/Exception/SignatureVerificationException.php:28
```