### PR TITLE
Release v4.1.1

### DIFF
--- a/src/Jobs/ProcessStripeWebhookJob.php
+++ b/src/Jobs/ProcessStripeWebhookJob.php
@@ -6,12 +6,15 @@ namespace Igniter\PayRegister\Jobs;
 
 use Igniter\Cart\Models\Order;
 use Igniter\PayRegister\Models\Payment;
+use Igniter\PayRegister\Payments\Stripe;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
+use Stripe\Checkout\Session;
+use Stripe\PaymentIntent;
 
 class ProcessStripeWebhookJob implements ShouldQueue
 {
@@ -40,22 +43,47 @@ class ProcessStripeWebhookJob implements ShouldQueue
 
     protected function handlePaymentIntentSucceeded(array $payload)
     {
+        $paymentObject = $payload['data']['object'];
+
         /** @var null|Order $order */
-        $order = Order::find($payload['data']['object']['metadata']['order_id']);
+        $order = Order::find($paymentObject['metadata']['order_id'] ?? null);
         if (!$order) {
             return;
         }
 
         if ($order->isPaymentProcessed()) {
-            $order->logPaymentAttempt('Payment already processed, skipping webhook', 0, [], $payload['data']['object']);
+            $order->logPaymentAttempt('Payment already processed, skipping webhook', 0, [], $paymentObject);
 
             return;
         }
 
-        if ($payload['data']['object']['status'] === 'requires_capture') {
-            $order->logPaymentAttempt('Payment authorized via webhook', 1, [], $payload['data']['object']);
+        $this->payment->applyGatewayClass();
+
+        /** @var null|Stripe $gateway */
+        $gateway = $this->payment->getGatewayObject();
+        if (!$gateway instanceof Stripe) {
+            return;
+        }
+
+        $intentId = $paymentObject['id'] ?? null;
+        if (!$intentId) {
+            $order->logPaymentAttempt('Payment verification failed: missing payment intent id', 0, [], $paymentObject);
+
+            return;
+        }
+
+        $paymentIntent = $gateway->verifyPaymentIntentForOrder($order, $intentId);
+        if (!$paymentIntent instanceof PaymentIntent) {
+            $order->logPaymentAttempt('Payment verification failed via webhook', 0, [], $paymentObject);
+
+            return;
+        }
+
+        $verifiedResponse = $paymentIntent->toArray();
+        if ($paymentIntent->status === 'requires_capture') {
+            $order->logPaymentAttempt('Payment authorized via webhook', 1, [], $verifiedResponse);
         } else {
-            $order->logPaymentAttempt('Payment successful via webhook', 1, [], $payload['data']['object'], true);
+            $order->logPaymentAttempt('Payment successful via webhook', 1, [], $verifiedResponse, true);
         }
 
         $order->updateOrderStatus($this->payment->order_status, ['notify' => false]);
@@ -64,16 +92,43 @@ class ProcessStripeWebhookJob implements ShouldQueue
 
     protected function handleCheckoutSessionCompleted(array $payload)
     {
+        $sessionObject = $payload['data']['object'];
+
         /** @var null|Order $order */
-        $order = Order::find($payload['data']['object']['metadata']['order_id']);
+        $order = Order::find($sessionObject['metadata']['order_id'] ?? null);
         if (!$order) {
             return;
         }
 
-        if ($payload['data']['object']['status'] === 'requires_capture') {
-            $order->logPaymentAttempt('Payment authorized via webhook', 1, [], $payload['data']['object']);
+        $this->payment->applyGatewayClass();
+
+        /** @var null|Stripe $gateway */
+        $gateway = $this->payment->getGatewayObject();
+        if (!$gateway instanceof Stripe) {
+            return;
+        }
+
+        $sessionId = $sessionObject['id'] ?? null;
+        if (!$sessionId) {
+            $order->logPaymentAttempt('Payment verification failed: missing checkout session id', 0, [], $sessionObject);
+
+            return;
+        }
+
+        $session = $gateway->verifyCheckoutSessionForOrder($order, $sessionId);
+        if (!$session instanceof Session) {
+            $order->logPaymentAttempt('Payment verification failed', 0, [], $sessionObject);
+
+            return;
+        }
+
+        $paymentIntent = $session->payment_intent;
+        $verifiedResponse = $paymentIntent->toArray();
+
+        if (is_object($paymentIntent) && $paymentIntent->status === 'requires_capture') {
+            $order->logPaymentAttempt('Payment authorized via webhook', 1, [], $verifiedResponse);
         } else {
-            $order->logPaymentAttempt('Payment successful via webhook', 1, [], $payload['data']['object'], true);
+            $order->logPaymentAttempt('Payment successful via webhook', 1, [], $verifiedResponse, true);
         }
 
         if (!$order->isPaymentProcessed()) {

--- a/src/Payments/PaypalExpress.php
+++ b/src/Payments/PaypalExpress.php
@@ -74,7 +74,7 @@ class PaypalExpress extends BasePaymentGateway
 
             $redirectUrl = collect($response->json('links', []))->where('rel', 'payer-action')->value('href');
             if ($response->ok() && $redirectUrl) {
-                return Redirect::to($redirectUrl);
+                return Redirect::to((string)$redirectUrl);
             }
 
             $order->logPaymentAttempt('Payment error -> '.$response->json('message'), 0, $fields, $response->json());
@@ -112,6 +112,14 @@ class PaypalExpress extends BasePaymentGateway
                 array_get($response, 'status') !== 'APPROVED',
                 new ApplicationException('Payment is not approved'),
             );
+
+            if (array_get($response, 'purchase_units.0.reference_id') !== $order->hash) {
+                throw new ApplicationException('Order reference does not match');
+            }
+
+            if (array_get($response, 'purchase_units.0.amount.value') !== number_format($order->order_total, 2, '.', '')) {
+                throw new ApplicationException('Payment amount does not match order total');
+            }
 
             if (array_get($response, 'intent') === 'CAPTURE') {
                 $response = $this->createClient()->captureOrder($token);

--- a/src/Payments/Stripe.php
+++ b/src/Payments/Stripe.php
@@ -22,6 +22,8 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Redirect;
 use Override;
+use Stripe\Checkout\Session;
+use Stripe\PaymentIntent;
 use Stripe\StripeClient;
 use Stripe\Webhook;
 
@@ -152,7 +154,7 @@ class Stripe extends BasePaymentGateway
                 $fields = $this->getPaymentFormFields($order);
                 $stripeOptions = $this->getStripeOptions();
                 $response = $this->createGateway()->paymentIntents->create(
-                    array_only($fields, ['amount', 'currency', 'capture_method', 'setup_future_usage', 'customer']), $stripeOptions,
+                    array_only($fields, ['amount', 'currency', 'metadata', 'capture_method', 'setup_future_usage', 'customer']), $stripeOptions,
                 );
 
                 $this->putSession($this->intentSessionKey, $response->id);
@@ -710,6 +712,74 @@ class Stripe extends BasePaymentGateway
         $this->fireSystemEvent('payregister.stripe.extendGateway', [$stripeClient]);
 
         return $stripeClient;
+    }
+
+    public function verifyPaymentIntentForOrder(Order $order, string $intentId): ?PaymentIntent
+    {
+        try {
+            $paymentIntent = $this->createGateway()->paymentIntents->retrieve(
+                $intentId,
+                [],
+                $this->getStripeOptions(),
+            );
+        } catch (Exception $ex) {
+            logger()->error($ex);
+
+            return null;
+        }
+
+        if ((string)array_get($paymentIntent->metadata->toArray(), 'order_id') !== (string)$order->order_id) {
+            return null;
+        }
+
+        if (!in_array($paymentIntent->status, ['requires_capture', 'succeeded'], true)) {
+            return null;
+        }
+
+        if ($paymentIntent->amount !== (int)number_format($order->order_total, 2, '', '')) {
+            return null;
+        }
+
+        return $paymentIntent;
+    }
+
+    public function verifyCheckoutSessionForOrder(Order $order, string $sessionId): ?Session
+    {
+        try {
+            $session = $this->createGateway()->checkout->sessions->retrieve(
+                $sessionId,
+                ['expand' => ['payment_intent']],
+                $this->getStripeOptions(),
+            );
+        } catch (Exception $ex) {
+            logger()->error($ex);
+
+            return null;
+        }
+
+        if ((string)array_get($session->metadata->toArray(), 'order_id') !== (string)$order->order_id) {
+            return null;
+        }
+
+        if ($session->status !== 'complete') {
+            return null;
+        }
+
+        if ($session->amount_total !== (int)number_format($order->order_total, 2, '', '')) {
+            return null;
+        }
+
+        $paymentIntent = $session->payment_intent;
+
+        if ($paymentIntent && !in_array($paymentIntent->status, ['requires_capture', 'succeeded'], true)) {
+            return null;
+        }
+
+        if ($paymentIntent->amount !== (int)number_format($order->order_total, 2, '', '')) {
+            return null;
+        }
+
+        return $session;
     }
 
     //

--- a/tests/Jobs/ProcessStripeWebhookJobTest.php
+++ b/tests/Jobs/ProcessStripeWebhookJobTest.php
@@ -7,14 +7,59 @@ namespace Igniter\PayRegister\Tests\Jobs;
 use Igniter\Cart\Models\Order;
 use Igniter\PayRegister\Jobs\ProcessStripeWebhookJob;
 use Igniter\PayRegister\Models\Payment;
+use Igniter\PayRegister\Payments\Cod;
+use Stripe\ApiRequestor as StripeApiRequestorAlias;
+use Stripe\HttpClient\CurlClient;
+
+beforeEach(function(): void {
+    StripeApiRequestorAlias::setHttpClient($this->httpClient = mock(CurlClient::class)->makePartial());
+});
+
+function setupStripePaymentMethod(Order $order): void
+{
+    $order->payment_method->transaction_mode = 'test';
+    $order->payment_method->test_secret_key = 'test_secret_key';
+    $order->payment_method->applyGatewayClass();
+}
+
+function setupVerifiedPaymentIntent(CurlClient $httpClient, Order $order, string $intentId, string $status): void
+{
+    setupStripeRequest($httpClient, 'payment_intents/'.$intentId, [
+        'id' => $intentId,
+        'object' => 'payment_intent',
+        'status' => $status,
+        'amount' => (int)number_format($order->order_total, 2, '', ''),
+        'metadata' => ['order_id' => (string)$order->order_id],
+    ]);
+}
+
+function setupVerifiedCheckoutSession(CurlClient $httpClient, Order $order, string $sessionId, string $paymentIntentStatus = 'succeeded'): void
+{
+    setupStripeRequest($httpClient, 'checkout/sessions/'.$sessionId, [
+        'id' => $sessionId,
+        'object' => 'checkout.session',
+        'status' => 'complete',
+        'amount_total' => (int)number_format($order->order_total, 2, '', ''),
+        'metadata' => ['order_id' => (string)$order->order_id],
+        'payment_intent' => [
+            'id' => 'pi_from_session',
+            'object' => 'payment_intent',
+            'status' => $paymentIntentStatus,
+            'amount' => (int)number_format($order->order_total, 2, '', ''),
+            'metadata' => ['order_id' => (string)$order->order_id],
+        ],
+    ]);
+}
 
 it('handles payment intent succeeded with valid order and successful status', function(): void {
-    $order = Order::factory()->create(['payment' => 'stripe']);
-    $order->payment_method->applyGatewayClass();
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
+    setupVerifiedPaymentIntent($this->httpClient, $order, 'pi_test_123', 'succeeded');
 
     $payload = [
         'data' => [
             'object' => [
+                'id' => 'pi_test_123',
                 'metadata' => ['order_id' => $order->getKey()],
                 'status' => 'succeeded',
             ],
@@ -33,12 +78,14 @@ it('handles payment intent succeeded with valid order and successful status', fu
 });
 
 it('handles payment intent succeeded with valid order and requires capture status', function(): void {
-    $order = Order::factory()->create(['payment' => 'stripe']);
-    $order->payment_method->applyGatewayClass();
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
+    setupVerifiedPaymentIntent($this->httpClient, $order, 'pi_test_123', 'requires_capture');
 
     $payload = [
         'data' => [
             'object' => [
+                'id' => 'pi_test_123',
                 'metadata' => ['order_id' => $order->getKey()],
                 'status' => 'requires_capture',
             ],
@@ -56,10 +103,92 @@ it('handles payment intent succeeded with valid order and requires capture statu
     ]);
 });
 
+it('does not mark order as paid when payment intent verification fails', function(): void {
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_test_123', [
+        'id' => 'pi_test_123',
+        'object' => 'payment_intent',
+        'status' => 'succeeded',
+        'amount' => 9999,
+        'metadata' => ['order_id' => (string)$order->order_id],
+    ]);
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'pi_test_123',
+                'metadata' => ['order_id' => $order->getKey()],
+                'status' => 'succeeded',
+            ],
+        ],
+    ];
+
+    $job = new ProcessStripeWebhookJob($order->payment_method, 'payment_intent.succeeded', $payload);
+    $job->handle();
+
+    $this->assertDatabaseHas('payment_logs', [
+        'order_id' => $order->getKey(),
+        'message' => 'Payment verification failed via webhook',
+        'is_success' => 0,
+        'is_refundable' => 0,
+    ]);
+    expect($order->fresh()->isPaymentProcessed())->toBeFalse();
+});
+
 it('skips processing when order is already processed', function(): void {
     $order = Order::factory()->create(['payment' => 'stripe']);
-    $order->payment_method->applyGatewayClass();
+    setupStripePaymentMethod($order);
     $order->markAsPaymentProcessed();
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'pi_test_123',
+                'metadata' => ['order_id' => $order->getKey()],
+                'status' => 'succeeded',
+            ],
+        ],
+    ];
+
+    $job = new ProcessStripeWebhookJob($order->payment_method, 'payment_intent.succeeded', $payload);
+    $job->handle();
+
+    $this->assertDatabaseHas('payment_logs', [
+        'order_id' => $order->getKey(),
+        'message' => 'Payment already processed, skipping webhook',
+        'is_success' => 0,
+        'is_refundable' => 0,
+    ]);
+});
+
+it('returns early when payment gateway is not stripe for payment intent succeeded', function(): void {
+    $payment = Payment::factory()->create(['class_name' => Cod::class]);
+    $order = Order::factory()->for($payment, 'payment_method')->create(['order_total' => 100]);
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'pi_test_123',
+                'metadata' => ['order_id' => $order->getKey()],
+                'status' => 'succeeded',
+            ],
+        ],
+    ];
+
+    $job = new ProcessStripeWebhookJob($payment, 'payment_intent.succeeded', $payload);
+    $job->handle();
+
+    $this->assertDatabaseMissing('payment_logs', [
+        'order_id' => $order->getKey(),
+        'message' => 'Payment successful via webhook',
+    ]);
+    expect($order->fresh()->isPaymentProcessed())->toBeFalse();
+});
+
+it('logs failure when payment intent id is missing from webhook payload', function(): void {
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
 
     $payload = [
         'data' => [
@@ -75,9 +204,8 @@ it('skips processing when order is already processed', function(): void {
 
     $this->assertDatabaseHas('payment_logs', [
         'order_id' => $order->getKey(),
-        'message' => 'Payment already processed, skipping webhook',
+        'message' => 'Payment verification failed: missing payment intent id',
         'is_success' => 0,
-        'is_refundable' => 0,
     ]);
 });
 
@@ -100,12 +228,14 @@ it('does nothing when order is not found', function(): void {
 });
 
 it('handles checkout session completed with valid order and successful status', function(): void {
-    $order = Order::factory()->create(['payment' => 'stripe']);
-    $order->payment_method->applyGatewayClass();
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
+    setupVerifiedCheckoutSession($this->httpClient, $order, 'cs_test_123');
 
     $payload = [
         'data' => [
             'object' => [
+                'id' => 'cs_test_123',
                 'metadata' => ['order_id' => $order->getKey()],
                 'status' => 'complete',
             ],
@@ -124,14 +254,16 @@ it('handles checkout session completed with valid order and successful status', 
 });
 
 it('handles checkout session completed with valid order and requires capture status', function(): void {
-    $order = Order::factory()->create(['payment' => 'stripe']);
-    $order->payment_method->applyGatewayClass();
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
+    setupVerifiedCheckoutSession($this->httpClient, $order, 'cs_test_123', 'requires_capture');
 
     $payload = [
         'data' => [
             'object' => [
+                'id' => 'cs_test_123',
                 'metadata' => ['order_id' => $order->getKey()],
-                'status' => 'requires_capture',
+                'status' => 'complete',
             ],
         ],
     ];
@@ -147,10 +279,100 @@ it('handles checkout session completed with valid order and requires capture sta
     ]);
 });
 
+it('does not mark order as paid when checkout session verification fails', function(): void {
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
+    setupStripeRequest($this->httpClient, 'checkout/sessions/cs_test_123', [
+        'id' => 'cs_test_123',
+        'object' => 'checkout.session',
+        'status' => 'complete',
+        'amount_total' => 9999,
+        'metadata' => ['order_id' => (string)$order->order_id],
+        'payment_intent' => [
+            'id' => 'pi_from_session',
+            'object' => 'payment_intent',
+            'status' => 'succeeded',
+            'amount' => 9999,
+            'metadata' => ['order_id' => (string)$order->order_id],
+        ],
+    ]);
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'cs_test_123',
+                'metadata' => ['order_id' => $order->getKey()],
+                'status' => 'complete',
+            ],
+        ],
+    ];
+
+    $job = new ProcessStripeWebhookJob($order->payment_method, 'checkout.session.completed', $payload);
+    $job->handle();
+
+    $this->assertDatabaseHas('payment_logs', [
+        'order_id' => $order->getKey(),
+        'message' => 'Payment verification failed',
+        'is_success' => 0,
+        'is_refundable' => 0,
+    ]);
+    expect($order->fresh()->isPaymentProcessed())->toBeFalse();
+});
+
 it('handles checkout session completed and skips order status update when already processed', function(): void {
-    $order = Order::factory()->create(['payment' => 'stripe']);
-    $order->payment_method->applyGatewayClass();
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
+    setupVerifiedCheckoutSession($this->httpClient, $order, 'cs_test_123');
     $order->markAsPaymentProcessed();
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'cs_test_123',
+                'metadata' => ['order_id' => $order->getKey()],
+                'status' => 'complete',
+            ],
+        ],
+    ];
+
+    $job = new ProcessStripeWebhookJob($order->payment_method, 'checkout.session.completed', $payload);
+    $job->handle();
+
+    $this->assertDatabaseHas('payment_logs', [
+        'order_id' => $order->getKey(),
+        'message' => 'Payment successful via webhook',
+        'is_success' => 1,
+        'is_refundable' => 1,
+    ]);
+    expect($order->fresh()->isPaymentProcessed())->toBeTrue();
+});
+
+it('returns early when payment gateway is not stripe for checkout session completed', function(): void {
+    $payment = Payment::factory()->create(['class_name' => Cod::class]);
+    $order = Order::factory()->for($payment, 'payment_method')->create(['order_total' => 100]);
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'cs_test_123',
+                'metadata' => ['order_id' => $order->getKey()],
+                'status' => 'complete',
+            ],
+        ],
+    ];
+
+    $job = new ProcessStripeWebhookJob($payment, 'checkout.session.completed', $payload);
+    $job->handle();
+
+    $this->assertDatabaseMissing('payment_logs', [
+        'order_id' => $order->getKey(),
+        'message' => 'Payment successful via webhook',
+    ]);
+});
+
+it('logs failure when checkout session id is missing from webhook payload', function(): void {
+    $order = Order::factory()->create(['payment' => 'stripe', 'order_total' => 100]);
+    setupStripePaymentMethod($order);
 
     $payload = [
         'data' => [
@@ -166,9 +388,8 @@ it('handles checkout session completed and skips order status update when alread
 
     $this->assertDatabaseHas('payment_logs', [
         'order_id' => $order->getKey(),
-        'message' => 'Payment successful via webhook',
-        'is_success' => 1,
-        'is_refundable' => 1,
+        'message' => 'Payment verification failed: missing checkout session id',
+        'is_success' => 0,
     ]);
 });
 

--- a/tests/Payments/PaypalExpressTest.php
+++ b/tests/Payments/PaypalExpressTest.php
@@ -175,7 +175,19 @@ it('processes paypal express return url and updates order status', function(stri
     }
 
     $paypalClient = Mockery::mock(PayPalClient::class)->makePartial();
-    $paypalClient->shouldReceive('getOrder')->andReturn(['status' => 'APPROVED', 'intent' => $transactionMode]);
+    $paypalClient->shouldReceive('getOrder')->andReturn([
+        'status' => 'APPROVED',
+        'intent' => $transactionMode,
+        'purchase_units' => [
+            [
+                'reference_id' => $order->hash,
+                'amount' => [
+                    'currency' => 'USD',
+                    'value' => number_format($order->order_total, 2, '.', ''),
+                ],
+            ],
+        ],
+    ]);
     $paypalClient->shouldReceive('captureOrder')->andReturn($response);
     $paypalClient->shouldReceive('authorizeOrder')->andReturn($response);
     app()->instance(PayPalClient::class, $paypalClient);
@@ -187,6 +199,156 @@ it('processes paypal express return url and updates order status', function(stri
     ['CAPTURE'],
     ['AUTHORIZE'],
 ]);
+
+it('redirects to cancel when paypal order reference does not match', function(): void {
+    request()->merge(['token' => 'test_token']);
+
+    $this->payment->applyGatewayClass();
+    $order = Order::factory()
+        ->for($this->payment, 'payment_method')
+        ->create(['order_total' => 100]);
+
+    $paypalClient = Mockery::mock(PayPalClient::class)->makePartial();
+    $paypalClient->shouldReceive('getOrder')->andReturn([
+        'status' => 'APPROVED',
+        'intent' => 'CAPTURE',
+        'purchase_units' => [
+            [
+                'reference_id' => 'invalid_hash',
+                'amount' => [
+                    'currency' => 'USD',
+                    'value' => number_format($order->order_total, 2, '.', ''),
+                ],
+            ],
+        ],
+    ]);
+    app()->instance(PayPalClient::class, $paypalClient);
+
+    $response = $this->paypalExpress->processReturnUrl([$order->hash]);
+
+    expect($response->getTargetUrl())->toContain('http://localhost/checkout')
+        ->and(flash()->messages()->first())->message->toContain('Order reference does not match');
+
+    $this->assertDatabaseHas('payment_logs', [
+        'order_id' => $order->order_id,
+        'message' => 'Payment error -> Order reference does not match',
+        'is_success' => 0,
+    ]);
+});
+
+it('redirects to cancel when paypal payment amount does not match order total', function(): void {
+    request()->merge(['token' => 'test_token']);
+
+    $this->payment->applyGatewayClass();
+    $order = Order::factory()
+        ->for($this->payment, 'payment_method')
+        ->create(['order_total' => 100]);
+
+    $paypalClient = Mockery::mock(PayPalClient::class)->makePartial();
+    $paypalClient->shouldReceive('getOrder')->andReturn([
+        'status' => 'APPROVED',
+        'intent' => 'CAPTURE',
+        'purchase_units' => [
+            [
+                'reference_id' => $order->hash,
+                'amount' => [
+                    'currency' => 'USD',
+                    'value' => '50.00',
+                ],
+            ],
+        ],
+    ]);
+    app()->instance(PayPalClient::class, $paypalClient);
+
+    $response = $this->paypalExpress->processReturnUrl([$order->hash]);
+
+    expect($response->getTargetUrl())->toContain('http://localhost/checkout')
+        ->and(flash()->messages()->first())->message->toContain('Payment amount does not match order total');
+
+    $this->assertDatabaseHas('payment_logs', [
+        'order_id' => $order->order_id,
+        'message' => 'Payment error -> Payment amount does not match order total',
+        'is_success' => 0,
+    ]);
+});
+
+it('redirects to success without marking order paid when paypal capture is not completed', function(): void {
+    request()->merge(['token' => 'test_token']);
+
+    $this->payment->applyGatewayClass();
+    $order = Order::factory()
+        ->for($this->payment, 'payment_method')
+        ->create(['order_total' => 100]);
+
+    $response = Mockery::mock(Response::class);
+    $response->shouldReceive('json')->withNoArgs()->andReturn([]);
+    $response->shouldReceive('json')->with('purchase_units.0.payments.captures.0.status')->andReturn('PENDING');
+
+    $paypalClient = Mockery::mock(PayPalClient::class)->makePartial();
+    $paypalClient->shouldReceive('getOrder')->andReturn([
+        'status' => 'APPROVED',
+        'intent' => 'CAPTURE',
+        'purchase_units' => [
+            [
+                'reference_id' => $order->hash,
+                'amount' => [
+                    'currency' => 'USD',
+                    'value' => number_format($order->order_total, 2, '.', ''),
+                ],
+            ],
+        ],
+    ]);
+    $paypalClient->shouldReceive('captureOrder')->andReturn($response);
+    app()->instance(PayPalClient::class, $paypalClient);
+
+    $result = $this->paypalExpress->processReturnUrl([$order->hash]);
+
+    expect($result->getTargetUrl())->toContain('http://localhost/checkout');
+    expect($order->fresh()->isPaymentProcessed())->toBeFalse();
+    $this->assertDatabaseMissing('payment_logs', [
+        'order_id' => $order->order_id,
+        'message' => 'Payment successful',
+    ]);
+});
+
+it('redirects to success without marking order paid when paypal authorization is not created', function(): void {
+    request()->merge(['token' => 'test_token']);
+
+    $this->payment->applyGatewayClass();
+    $order = Order::factory()
+        ->for($this->payment, 'payment_method')
+        ->create(['order_total' => 100]);
+
+    $response = Mockery::mock(Response::class);
+    $response->shouldReceive('json')->withNoArgs()->andReturn([]);
+    $response->shouldReceive('json')->with('purchase_units.0.payments.authorizations.0.status')->andReturn('DENIED');
+
+    $paypalClient = Mockery::mock(PayPalClient::class)->makePartial();
+    $paypalClient->shouldReceive('getOrder')->andReturn([
+        'status' => 'APPROVED',
+        'intent' => 'AUTHORIZE',
+        'purchase_units' => [
+            [
+                'reference_id' => $order->hash,
+                'amount' => [
+                    'currency' => 'USD',
+                    'value' => number_format($order->order_total, 2, '.', ''),
+                ],
+            ],
+        ],
+    ]);
+    $paypalClient->shouldReceive('authorizeOrder')->andReturn($response);
+    app()->instance(PayPalClient::class, $paypalClient);
+
+    $result = $this->paypalExpress->processReturnUrl([$order->hash]);
+
+    expect($result->getTargetUrl())->toContain('http://localhost/checkout');
+    expect($order->fresh()->isPaymentProcessed())->toBeFalse();
+    $this->assertDatabaseMissing('payment_logs', [
+        'order_id' => $order->order_id,
+        'message' => 'Payment authorized',
+    ]);
+});
 
 it('throws exception when no order found in paypal express return url', function(): void {
     request()->merge([

--- a/tests/Payments/StripeTest.php
+++ b/tests/Payments/StripeTest.php
@@ -23,7 +23,6 @@ use Mockery;
 use Stripe\ApiRequestor as StripeApiRequestorAlias;
 use Stripe\HttpClient\CurlClient;
 use Stripe\StripeObject;
-use Stripe\Util\CaseInsensitiveArray;
 
 beforeEach(function(): void {
     $this->payment = Payment::factory()->create([
@@ -32,17 +31,6 @@ beforeEach(function(): void {
     $this->stripe = new Stripe($this->payment);
     StripeApiRequestorAlias::setHttpClient($this->httpClient = mock(CurlClient::class)->makePartial());
 });
-
-function setupRequest(CurlClient $httpClient, string $uri, array $response, string $method = 'get', int $statusCode = 200): void
-{
-    $httpClient->shouldReceive('request')
-        ->with($method, 'https://api.stripe.com/v1/'.$uri, Mockery::any(), Mockery::any(), false)
-        ->andReturn([
-            json_encode($response),
-            200,
-            new CaseInsensitiveArray(['Request-Id' => 'req_123']),
-        ]);
-}
 
 it('returns correct payment form view for stripe', function(): void {
     expect(Stripe::$paymentFormView)->toBe('igniter.payregister::_partials.stripe.payment_form');
@@ -146,10 +134,10 @@ it('creates stripe payment intent successfully', function(): void {
         ->for(Customer::factory()->create(), 'customer')
         ->for($this->payment, 'payment_method')
         ->create(['order_total' => 100]);
-    setupRequest($this->httpClient, 'customers', [
+    setupStripeRequest($this->httpClient, 'customers', [
         'id' => 'cus_123',
     ], 'post');
-    setupRequest($this->httpClient, 'payment_intents', [
+    setupStripeRequest($this->httpClient, 'payment_intents', [
         'id' => 'pi_123',
         'client_secret' => 'secret',
     ], 'post');
@@ -164,11 +152,11 @@ it('fetches & updates stripe payment intent successfully', function(): void {
         ->for($this->payment, 'payment_method')
         ->create(['order_total' => 100]);
     $this->stripe->putSession('ti_payregister_stripe_intent', 'pi_123');
-    setupRequest($this->httpClient, 'payment_intents/pi_123', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123', [
         'id' => 'pi_123',
         'status' => 'not-succeeded',
     ]);
-    setupRequest($this->httpClient, 'payment_intents', [
+    setupStripeRequest($this->httpClient, 'payment_intents', [
         'id' => 'pi_123',
         'client_secret' => 'secret',
     ], 'post');
@@ -209,7 +197,7 @@ it('processes stripe payment form successfully', function(): void {
     $this->payment->test_secret_key = 'test_secret_key';
     $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
     $this->stripe->putSession('ti_payregister_stripe_intent', 'pi_123');
-    setupRequest($this->httpClient, 'payment_intents/pi_123', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123', [
         'id' => 'pi_123',
         'status' => 'succeeded',
     ]);
@@ -265,7 +253,7 @@ it('logs error and throws exception when payment intent status is not succeeded'
     $this->payment->test_secret_key = 'test_secret_key';
     $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
     $this->stripe->putSession('ti_payregister_stripe_intent', 'pi_123');
-    setupRequest($this->httpClient, 'payment_intents/pi_123', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123', [
         'id' => 'pi_123',
         'status' => 'not_succeeded',
     ]);
@@ -285,7 +273,7 @@ it('updates payment profile on process payment form success', function(): void {
         ->for($this->payment, 'payment_method')
         ->create(['order_total' => 100]);
     $this->stripe->putSession('ti_payregister_stripe_intent', 'pi_123');
-    setupRequest($this->httpClient, 'payment_intents/pi_123', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123', [
         'id' => 'pi_123',
         'status' => 'requires_capture',
         'payment_method' => [
@@ -318,7 +306,7 @@ it('captures authorized payment successfully', function(): void {
         'is_success' => 1,
         'response' => ['id' => 'pi_123'],
     ]);
-    setupRequest($this->httpClient, 'payment_intents/pi_123/capture', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123/capture', [
         'id' => 'pi_123',
         'status' => 'succeeded',
     ], 'post');
@@ -410,7 +398,7 @@ it('logs error when capture authorized payment response is invalid', function():
         'is_success' => 1,
         'response' => ['id' => 'pi_123'],
     ]);
-    setupRequest($this->httpClient, 'payment_intents/pi_123/capture', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123/capture', [
         'id' => 'pi_123',
         'status' => 'invalid',
     ], 'post');
@@ -436,7 +424,7 @@ it('cancels authorized stripe payment successfully', function(): void {
         'is_success' => 1,
         'response' => ['id' => 'pi_123'],
     ]);
-    setupRequest($this->httpClient, 'payment_intents/pi_123/cancel', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123/cancel', [
         'id' => 'pi_123',
         'status' => 'canceled',
     ], 'post');
@@ -522,7 +510,7 @@ it('logs error when canceling authorized payment response is invalid', function(
         'is_success' => 1,
         'response' => ['id' => 'pi_123'],
     ]);
-    setupRequest($this->httpClient, 'payment_intents/pi_123/cancel', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123/cancel', [
         'id' => 'pi_123',
         'status' => 'invalid',
     ], 'post');
@@ -544,7 +532,7 @@ it('returns stripe payment intent if status is requires_capture or succeeded', f
         ->for($this->payment, 'payment_method')
         ->create(['order_total' => 100]);
     $this->stripe->putSession('ti_payregister_stripe_intent', 'pi_123');
-    setupRequest($this->httpClient, 'payment_intents/pi_123', [
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_123', [
         'id' => 'pi_123',
         'status' => 'succeeded',
     ]);
@@ -560,7 +548,7 @@ it('deletes existing payment profile', function(): void {
         'payment_id' => $this->payment->getKey(),
         'profile_data' => ['card_id' => 'card_123', 'customer_id' => 'cus_123'],
     ]);
-    setupRequest($this->httpClient, 'customers/cus_123', [
+    setupStripeRequest($this->httpClient, 'customers/cus_123', [
         'id' => 'cus_123',
     ], 'delete');
 
@@ -592,14 +580,14 @@ it('creates payment successfully from stripe payment profile', function(): void 
         'payment_id' => $this->payment->getKey(),
         'profile_data' => ['card_id' => 'card_123', 'customer_id' => 'cus_123'],
     ]);
-    setupRequest($this->httpClient, 'customers/cus_123', [
+    setupStripeRequest($this->httpClient, 'customers/cus_123', [
         'id' => 'cus_123',
         'deleted' => true,
     ]);
-    setupRequest($this->httpClient, 'customers', [
+    setupStripeRequest($this->httpClient, 'customers', [
         'id' => 'cus_123',
     ], 'post');
-    setupRequest($this->httpClient, 'payment_intents', [
+    setupStripeRequest($this->httpClient, 'payment_intents', [
         'id' => 'pi_123',
         'status' => 'succeeded',
     ], 'post');
@@ -626,14 +614,14 @@ it('logs payment attempt and throws exception when payment request fails', funct
         'payment_id' => $this->payment->getKey(),
         'profile_data' => ['card_id' => 'card_123', 'customer_id' => 'cus_123'],
     ]);
-    setupRequest($this->httpClient, 'customers/cus_123', [
+    setupStripeRequest($this->httpClient, 'customers/cus_123', [
         'id' => 'cus_123',
         'deleted' => true,
     ]);
-    setupRequest($this->httpClient, 'customers', [
+    setupStripeRequest($this->httpClient, 'customers', [
         'id' => 'cus_123',
     ], 'post');
-    setupRequest($this->httpClient, 'payment_intents', [
+    setupStripeRequest($this->httpClient, 'payment_intents', [
         'id' => 'pi_123',
         'status' => 'invalid',
     ], 'post');
@@ -710,7 +698,7 @@ it('processes refund form and logs refund attempt', function(): void {
         'is_refundable' => 1,
         'response' => ['id' => 'pi_123', 'status' => 'succeeded', 'object' => 'payment_intent'],
     ]);
-    setupRequest($this->httpClient, 'refunds', [
+    setupStripeRequest($this->httpClient, 'refunds', [
         'id' => 're_123',
         'status' => 'succeeded',
     ], 'post');
@@ -784,7 +772,7 @@ it('throws exception when refund response fails', function(): void {
         'is_refundable' => 1,
         'response' => ['id' => 'pi_123', 'status' => 'succeeded', 'object' => 'payment_intent'],
     ]);
-    setupRequest($this->httpClient, 'refunds', [
+    setupStripeRequest($this->httpClient, 'refunds', [
         'id' => 're_123',
         'status' => 'failed',
     ], 'post');
@@ -813,10 +801,10 @@ it('redirects to stripe checkout when offsite mode is enabled', function(): void
         'payment_id' => $this->payment->getKey(),
         'profile_data' => ['customer_id' => 'cus_existing123'],
     ]);
-    setupRequest($this->httpClient, 'customers/cus_existing123', [
+    setupStripeRequest($this->httpClient, 'customers/cus_existing123', [
         'id' => 'cus_existing123',
     ]);
-    setupRequest($this->httpClient, 'checkout/sessions', [
+    setupStripeRequest($this->httpClient, 'checkout/sessions', [
         'id' => 'cs_123',
         'url' => 'https://checkout.stripe.com/pay/cs_123',
     ], 'post');
@@ -840,10 +828,10 @@ it('creates new customer for checkout session when profile has no customer_id', 
         ->for($customer, 'customer')
         ->for($this->payment, 'payment_method')
         ->create(['order_total' => 100]);
-    setupRequest($this->httpClient, 'customers', [
+    setupStripeRequest($this->httpClient, 'customers', [
         'id' => 'cus_new123',
     ], 'post');
-    setupRequest($this->httpClient, 'checkout/sessions', [
+    setupStripeRequest($this->httpClient, 'checkout/sessions', [
         'id' => 'cs_123',
         'url' => 'https://checkout.stripe.com/pay/cs_123',
     ], 'post');
@@ -860,7 +848,7 @@ it('does not include customer data in checkout session when order has no custome
     $order = Order::factory()
         ->for($this->payment, 'payment_method')
         ->create(['order_total' => 100]);
-    setupRequest($this->httpClient, 'checkout/sessions', [
+    setupStripeRequest($this->httpClient, 'checkout/sessions', [
         'id' => 'cs_123',
         'url' => 'https://checkout.stripe.com/pay/cs_123',
     ], 'post');
@@ -1017,7 +1005,7 @@ it('fires event to extend checkout session fields', function(): void {
         $fields['custom_field'] = 'custom_value';
     });
 
-    setupRequest($this->httpClient, 'checkout/sessions', [
+    setupStripeRequest($this->httpClient, 'checkout/sessions', [
         'id' => 'cs_123',
         'url' => 'https://checkout.stripe.com/pay/cs_123',
     ], 'post');
@@ -1135,4 +1123,155 @@ it('handles webhook event with webhook secret', function(): void {
 
     Event::assertDispatched('payregister.stripe.webhook.handle');
     Queue::assertPushed(ProcessStripeWebhookJob::class);
+});
+
+it('returns null when verifying payment intent fails due to stripe api error', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    $this->httpClient->shouldReceive('request')->andThrow(new Exception('Stripe API error'));
+
+    expect($this->stripe->verifyPaymentIntentForOrder($order, 'pi_test_123'))->toBeNull();
+});
+
+it('returns null when verifying payment intent with mismatched order metadata', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_test_123', [
+        'id' => 'pi_test_123',
+        'object' => 'payment_intent',
+        'status' => 'succeeded',
+        'amount' => 10000,
+        'metadata' => ['order_id' => '99999'],
+    ]);
+
+    expect($this->stripe->verifyPaymentIntentForOrder($order, 'pi_test_123'))->toBeNull();
+});
+
+it('returns null when verifying payment intent with invalid status', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_test_123', [
+        'id' => 'pi_test_123',
+        'object' => 'payment_intent',
+        'status' => 'processing',
+        'amount' => 10000,
+        'metadata' => ['order_id' => (string)$order->order_id],
+    ]);
+
+    expect($this->stripe->verifyPaymentIntentForOrder($order, 'pi_test_123'))->toBeNull();
+});
+
+it('returns null when verifying payment intent with mismatched amount', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    setupStripeRequest($this->httpClient, 'payment_intents/pi_test_123', [
+        'id' => 'pi_test_123',
+        'object' => 'payment_intent',
+        'status' => 'succeeded',
+        'amount' => 9999,
+        'metadata' => ['order_id' => (string)$order->order_id],
+    ]);
+
+    expect($this->stripe->verifyPaymentIntentForOrder($order, 'pi_test_123'))->toBeNull();
+});
+
+it('returns null when verifying checkout session fails due to stripe api error', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    $this->httpClient->shouldReceive('request')->andThrow(new Exception('Stripe API error'));
+
+    expect($this->stripe->verifyCheckoutSessionForOrder($order, 'cs_test_123'))->toBeNull();
+});
+
+it('returns null when verifying checkout session with mismatched order metadata', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    setupStripeRequest($this->httpClient, 'checkout/sessions/cs_test_123', [
+        'id' => 'cs_test_123',
+        'object' => 'checkout.session',
+        'status' => 'complete',
+        'amount_total' => 10000,
+        'metadata' => ['order_id' => '99999'],
+        'payment_intent' => [
+            'id' => 'pi_from_session',
+            'object' => 'payment_intent',
+            'status' => 'succeeded',
+            'amount' => 10000,
+            'metadata' => ['order_id' => '99999'],
+        ],
+    ]);
+
+    expect($this->stripe->verifyCheckoutSessionForOrder($order, 'cs_test_123'))->toBeNull();
+});
+
+it('returns null when verifying checkout session that is not complete', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    setupStripeRequest($this->httpClient, 'checkout/sessions/cs_test_123', [
+        'id' => 'cs_test_123',
+        'object' => 'checkout.session',
+        'status' => 'open',
+        'amount_total' => 10000,
+        'metadata' => ['order_id' => (string)$order->order_id],
+        'payment_intent' => [
+            'id' => 'pi_from_session',
+            'object' => 'payment_intent',
+            'status' => 'succeeded',
+            'amount' => 10000,
+            'metadata' => ['order_id' => (string)$order->order_id],
+        ],
+    ]);
+
+    expect($this->stripe->verifyCheckoutSessionForOrder($order, 'cs_test_123'))->toBeNull();
+});
+
+it('returns null when verifying checkout session with invalid payment intent status', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    setupStripeRequest($this->httpClient, 'checkout/sessions/cs_test_123', [
+        'id' => 'cs_test_123',
+        'object' => 'checkout.session',
+        'status' => 'complete',
+        'amount_total' => 10000,
+        'metadata' => ['order_id' => (string)$order->order_id],
+        'payment_intent' => [
+            'id' => 'pi_from_session',
+            'object' => 'payment_intent',
+            'status' => 'processing',
+            'amount' => 10000,
+            'metadata' => ['order_id' => (string)$order->order_id],
+        ],
+    ]);
+
+    expect($this->stripe->verifyCheckoutSessionForOrder($order, 'cs_test_123'))->toBeNull();
+});
+
+it('returns null when verifying checkout session with mismatched payment intent amount', function(): void {
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_secret_key = 'test_secret_key';
+    $order = Order::factory()->for($this->payment, 'payment_method')->create(['order_total' => 100]);
+    setupStripeRequest($this->httpClient, 'checkout/sessions/cs_test_123', [
+        'id' => 'cs_test_123',
+        'object' => 'checkout.session',
+        'status' => 'complete',
+        'amount_total' => 10000,
+        'metadata' => ['order_id' => (string)$order->order_id],
+        'payment_intent' => [
+            'id' => 'pi_from_session',
+            'object' => 'payment_intent',
+            'status' => 'succeeded',
+            'amount' => 9999,
+            'metadata' => ['order_id' => (string)$order->order_id],
+        ],
+    ]);
+
+    expect($this->stripe->verifyCheckoutSessionForOrder($order, 'cs_test_123'))->toBeNull();
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,10 +4,23 @@ declare(strict_types=1);
 
 use Igniter\User\Models\User;
 use SamPoyigi\Testbench\TestCase;
+use Stripe\HttpClient\CurlClient;
+use Stripe\Util\CaseInsensitiveArray;
 
 uses(TestCase::class)->in(__DIR__);
 
 function actingAsSuperUser()
 {
     return test()->actingAs(User::factory()->superUser()->create(), 'igniter-admin');
+}
+
+function setupStripeRequest(CurlClient $httpClient, string $uri, array $response, string $method = 'get', int $statusCode = 200): void
+{
+    $httpClient->shouldReceive('request')
+        ->with($method, 'https://api.stripe.com/v1/'.$uri, Mockery::any(), Mockery::any(), false)
+        ->andReturn([
+            json_encode($response),
+            200,
+            new CaseInsensitiveArray(['Request-Id' => 'req_123']),
+        ]);
 }


### PR DESCRIPTION
This release improves payment reliability by adding verification steps for Stripe webhook events and strengthening PayPal order validation before capture.

## Added

- Payment verification check before processing Stripe webhook events to ensure only valid events are handled

## Fixed

- PayPal order reference and amount are now validated before capture to prevent processing invalid or mismatched orders