### PR TITLE
fix(paypal): select API host by the configured sandbox mode, not app environment

### DIFF
--- a/src/Classes/PayPalClient.php
+++ b/src/Classes/PayPalClient.php
@@ -84,7 +84,9 @@ class PayPalClient
         throw_unless($this->clientId, ApplicationException::class, 'PayPal client ID is not configured');
         throw_unless($this->clientSecret, ApplicationException::class, 'PayPal client secret is not configured');
 
-        if (!cache()->has('payregister_paypal_access_token')) {
+        $cacheKey = 'payregister_paypal_access_token'.($this->sandbox ? '_sandbox' : '');
+
+        if (!cache()->has($cacheKey)) {
             $response = Http::asForm()
                 ->withBasicAuth($this->clientId, $this->clientSecret)
                 ->post($this->endpoint('v1/oauth2/token'), [
@@ -95,16 +97,16 @@ class PayPalClient
                 throw new ApplicationException('Failed to generate access token');
             }
 
-            cache()->put('payregister_paypal_access_token', $response->json('access_token'), $response->json('expires_in') - 60);
+            cache()->put($cacheKey, $response->json('access_token'), $response->json('expires_in') - 60);
         }
 
-        return 'Bearer '.cache()->get('payregister_paypal_access_token');
+        return 'Bearer '.cache()->get($cacheKey);
     }
 
     protected function endpoint(string $uri): string
     {
         $endpoint = 'https://';
-        $endpoint .= app()->environment('production') ? 'api-m.paypal.com/' : 'api-m.sandbox.paypal.com/';
+        $endpoint .= $this->sandbox ? 'api-m.sandbox.paypal.com/' : 'api-m.paypal.com/';
 
         return $endpoint.$uri;
     }

--- a/tests/Classes/PayPalClientTest.php
+++ b/tests/Classes/PayPalClientTest.php
@@ -21,9 +21,9 @@ beforeEach(function(): void {
 
 function mockGenerateAccessToken(): void
 {
-    Cache::shouldReceive('has')->with('payregister_paypal_access_token')->andReturn(false);
+    Cache::shouldReceive('has')->with('payregister_paypal_access_token_sandbox')->andReturn(false);
     Cache::shouldReceive('put')->once();
-    Cache::shouldReceive('get')->with('payregister_paypal_access_token')->andReturn('testAccessToken');
+    Cache::shouldReceive('get')->with('payregister_paypal_access_token_sandbox')->andReturn('testAccessToken');
 
     Http::fake([
         'https://api-m.sandbox.paypal.com/v1/oauth2/token' => Http::response([
@@ -124,7 +124,7 @@ it('refunds payment successfully', function(): void {
 });
 
 it('throws exception if access token generation fails', function(): void {
-    Cache::shouldReceive('has')->with('payregister_paypal_access_token')->andReturn(false);
+    Cache::shouldReceive('has')->with('payregister_paypal_access_token_sandbox')->andReturn(false);
 
     Http::fake([
         'https://api-m.sandbox.paypal.com/v1/oauth2/token' => Http::response([], 400),
@@ -134,4 +134,27 @@ it('throws exception if access token generation fails', function(): void {
     $this->expectExceptionMessage('Failed to generate access token');
 
     $this->payPalClient->getOrder('123');
+});
+
+it('targets the live api host when not in sandbox mode', function(): void {
+    Cache::shouldReceive('has')->with('payregister_paypal_access_token')->andReturn(false);
+    Cache::shouldReceive('put')->once();
+    Cache::shouldReceive('get')->with('payregister_paypal_access_token')->andReturn('testAccessToken');
+
+    Http::fake([
+        'https://api-m.paypal.com/v1/oauth2/token' => Http::response([
+            'access_token' => 'testAccessToken',
+            'expires_in' => 3600,
+        ], 200),
+        'https://api-m.paypal.com/v2/checkout/orders/*' => Http::response(['id' => 'testOrderId'], 200),
+    ]);
+
+    $client = new PayPalClient;
+    $client->setClientId('testClientId');
+    $client->setClientSecret('testClientSecret');
+    $client->setSandbox(false);
+
+    $response = $client->getOrder('testOrderId');
+
+    expect($response->json('id'))->toBe('testOrderId');
 });


### PR DESCRIPTION
### The bug

`PayPalClient::endpoint()` selects the API host from the app environment instead of the sandbox flag the gateway configures:

```php
$endpoint .= app()->environment('production') ? 'api-m.paypal.com/' : 'api-m.sandbox.paypal.com/';
```

`PaypalExpress::createClient()` calls `$client->setSandbox($this->isSandboxMode())` from the payment's `api_mode` setting, but the flag is never consulted. Consequences:

- On a production install (`APP_ENV=production`), **sandbox mode can never authenticate** — the sandbox client id/secret are sent to the live host, and every attempt fails with *"Failed to generate access token"*. This makes it impossible to test PayPal on a real deployment before going live.
- On any non-production environment, **live mode silently targets the sandbox host** with live credentials.

### The fix

- `endpoint()` now selects the host from `$this->sandbox` (the flag `setSandbox()` already sets).
- The cached access token is scoped per mode (`payregister_paypal_access_token` / `…_sandbox`) so switching `api_mode` on a running install cannot reuse a token issued for the other host.
- Added a regression test that live mode targets `api-m.paypal.com`; updated the existing cache-key mocks to the sandbox-scoped key (the test fixture runs with `setSandbox(true)`).

### Verified

Reproduced on a production-mode install: sandbox checkout failed with *Failed to generate access token*; with this change the same credentials complete a full sandbox purchase (redirect → approve → capture → order marked paid). `tests/Classes/PayPalClientTest.php`: 10 passed (20 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
