### PR TITLE
fix(mollie): return customers to the success page after payment

### DIFF
--- a/src/Payments/Mollie.php
+++ b/src/Payments/Mollie.php
@@ -113,32 +113,34 @@ class Mollie extends BasePaymentGateway
                 new ApplicationException('No valid payment method found'),
             );
 
-            $paymentId = array_get(PaymentLog::where('order_id', $order->order_id)
-                ->where('payment_code', $paymentMethod->code)
-                ->where('message', 'redirecting-to-payment-gateway')
-                ->value('response') ?? [], 'id');
+            // The notify webhook usually confirms the payment before the customer
+            // returns — an already processed order is the success case, not an error.
+            if (!$order->isPaymentProcessed()) {
+                $paymentId = array_get(PaymentLog::where('order_id', $order->order_id)
+                    ->where('payment_code', $paymentMethod->code)
+                    ->where('message', 'redirecting-to-payment-gateway')
+                    ->value('response') ?? [], 'id');
 
-            throw_unless(
-                !$paymentId,
-                new ApplicationException('Missing payment id in payment attempt records'),
-            );
+                throw_unless(
+                    $paymentId,
+                    new ApplicationException('Missing payment id in payment attempt records'),
+                );
 
-            throw_unless(
-                $payment = $this->createClient()->payments->get($paymentId),
-                new ApplicationException(sprintf('Payment not found for %s', $paymentId)),
-            );
+                throw_unless(
+                    $payment = $this->createClient()->payments->get($paymentId),
+                    new ApplicationException(sprintf('Payment not found for %s', $paymentId)),
+                );
 
-            throw_if($order->isPaymentProcessed(), new ApplicationException('Payment has already been processed'));
-
-            if ($payment->isPaid() && data_get($payment->metadata, 'order_id') == $order->order_id) {
-                $order->logPaymentAttempt('Payment successful', 1, [], [
-                    'id' => $payment->id,
-                    'status' => $payment->status,
-                    'method' => $payment->method,
-                    'amount' => $payment->amount,
-                ], true);
-                $order->updateOrderStatus($paymentMethod->order_status, ['notify' => false]);
-                $order->markAsPaymentProcessed();
+                if ($payment->isPaid() && data_get($payment->metadata, 'order_id') == $order->order_id) {
+                    $order->logPaymentAttempt('Payment successful', 1, [], [
+                        'id' => $payment->id,
+                        'status' => $payment->status,
+                        'method' => $payment->method,
+                        'amount' => $payment->amount,
+                    ], true);
+                    $order->updateOrderStatus($paymentMethod->order_status, ['notify' => false]);
+                    $order->markAsPaymentProcessed();
+                }
             }
 
             return Redirect::to(page_url($redirectPage, [

--- a/tests/Payments/MollieTest.php
+++ b/tests/Payments/MollieTest.php
@@ -198,12 +198,16 @@ it('processes mollie return url and updates order status', function(): void {
         ->for(Customer::factory()->create(), 'customer')
         ->for($this->payment, 'payment_method')
         ->create(['order_total' => 100]);
+    $order->logPaymentAttempt('redirecting-to-payment-gateway', 0, [], [
+        'id' => 'tr_test123',
+        'status' => 'open',
+    ]);
 
     $molliePayment = Mockery::mock(MolliePayment::class);
     $molliePayment->shouldReceive('isPaid')->andReturn(true)->once();
     $molliePayment->metadata = ['order_id' => $order->getKey()];
     $paymentEndpoint = Mockery::mock(PaymentEndpoint::class);
-    $paymentEndpoint->shouldReceive('get')->andReturn($molliePayment)->once();
+    $paymentEndpoint->shouldReceive('get')->with('tr_test123')->andReturn($molliePayment)->once();
     $mollieClient = Mockery::mock(MollieApiClient::class)->makePartial();
     $mollieClient->payments = $paymentEndpoint;
     app()->instance(MollieApiClient::class, $mollieClient);
@@ -218,6 +222,54 @@ it('processes mollie return url and updates order status', function(): void {
         'is_success' => 1,
         'is_refundable' => 1,
     ]);
+});
+
+it('redirects to the success page when the webhook already processed the payment', function(): void {
+    request()->merge([
+        'redirect' => 'http://redirect.url',
+        'cancel' => 'http://cancel.url',
+    ]);
+
+    Mail::fake();
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_api_key = 'test_'.str_random(30);
+    $this->payment->applyGatewayClass();
+    $order = Order::factory()
+        ->for(Customer::factory()->create(), 'customer')
+        ->for($this->payment, 'payment_method')
+        ->create(['order_total' => 100]);
+    $order->markAsPaymentProcessed();
+
+    $paymentEndpoint = Mockery::mock(PaymentEndpoint::class);
+    $paymentEndpoint->shouldReceive('get')->never();
+    $mollieClient = Mockery::mock(MollieApiClient::class)->makePartial();
+    $mollieClient->payments = $paymentEndpoint;
+    app()->instance(MollieApiClient::class, $mollieClient);
+
+    $response = $this->mollie->processReturnUrl([$order->hash]);
+
+    expect($response->getTargetUrl())->toContain('http://redirect.url');
+});
+
+it('redirects to cancel page when no payment attempt record exists', function(): void {
+    request()->merge([
+        'redirect' => 'http://redirect.url',
+        'cancel' => 'http://cancel.url',
+    ]);
+
+    Mail::fake();
+    $this->payment->transaction_mode = 'test';
+    $this->payment->test_api_key = 'test_'.str_random(30);
+    $this->payment->applyGatewayClass();
+    $order = Order::factory()
+        ->for(Customer::factory()->create(), 'customer')
+        ->for($this->payment, 'payment_method')
+        ->create(['order_total' => 100]);
+
+    $response = $this->mollie->processReturnUrl([$order->hash]);
+
+    expect($response->getTargetUrl())->toContain('http://cancel.url')
+        ->and(flash()->messages()->first())->message->toBe('Missing payment id in payment attempt records')->level->toBe('warning');
 });
 
 it('throws exception if no order found in mollie return url', function(): void {


### PR DESCRIPTION
### The bug

Every customer who successfully pays via Mollie is redirected back to the **checkout page with a warning** instead of the order confirmation. The order itself is still marked paid (the notify webhook handles that server-side), so the failure is invisible in the back office — only the customer sees it.

Two issues in `Mollie::processReturnUrl()` combine to cause this:

1. **Inverted guard** — this throws precisely when the payment attempt record IS found (i.e. always, in the normal flow):

```php
throw_unless(
    !$paymentId,
    new ApplicationException('Missing payment id in payment attempt records'),
);
```

2. **Webhook race treated as an error** — Mollie calls the `webhookUrl` server-to-server, which normally confirms the payment before the customer's browser hits the return URL. The return handler then threw *"Payment has already been processed"* and sent the customer to the cancel page:

```php
throw_if($order->isPaymentProcessed(), new ApplicationException('Payment has already been processed'));
```

The existing return-url test passed by accident: it never seeded a `redirecting-to-payment-gateway` payment log, so `$paymentId` was `null`, the inverted guard let it through, and the mocked payments endpoint returned a payment for the `null` id.

### The fix

- Corrected the guard to throw when the payment attempt record is *missing*.
- An already processed order now redirects to the success page (webhook won the race — that's the success case); otherwise the handler verifies and processes the payment itself as before.
- Updated the return-url test to seed the payment attempt record (and pin the mocked `payments->get()` to that id), and added tests for the webhook-already-processed path and the genuinely-missing-record path.

### Verified

Reproduced end-to-end on a live test-mode install (public webhook URL): test-card payment → webhook confirms → customer bounced to checkout with a warning. With this change the customer lands on the order confirmation; both confirmation paths log `Payment successful` exactly once each. `tests/Payments/MollieTest.php`: 21 passed (54 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
